### PR TITLE
ci: update tox-lsr to version 3.0.0

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -33,4 +33,4 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v3
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"


### PR DESCRIPTION
The major version bump is because tox-lsr 3 drops support
for tox version 2.  If you are using tox 2 you will need to
upgrade to tox 3 or 4.

tox-lsr 3.0.0 adds support for tox 4, commitlint, and ansible-lint-collection

See https://github.com/linux-system-roles/tox-lsr/releases/tag/3.0.0
for full release notes
