### PR TITLE
Add pull request template and run commitlint on PR title only

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -1,5 +1,6 @@
 present_files:
   - .github/dependabot.yml
+  - .github/pull_request_template.md
   - .commitlintrc.js
 present_templates:
   - .ansible-lint

--- a/playbooks/files/.github/pull_request_template.md
+++ b/playbooks/files/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+Enhancement:
+
+Reason:
+
+Result:
+
+Issue Tracker Ticket(Jira or BZ if any):

--- a/playbooks/files/.github/pull_request_template.md
+++ b/playbooks/files/.github/pull_request_template.md
@@ -4,4 +4,4 @@ Reason:
 
 Result:
 
-Issue Tracker Ticket(Jira or BZ if any):
+Issue Tracker Tickets (Jira or BZ if any):

--- a/playbooks/templates/.github/workflows/commitlint.yml
+++ b/playbooks/templates/.github/workflows/commitlint.yml
@@ -24,22 +24,6 @@ jobs:
       - name: Install conventional-commit linter
         run: npm install @commitlint/config-conventional @commitlint/cli
 
-      # Finding the commit range is not as trivial as it may seem.
-      #
-      # At this stage, git's HEAD does not refer to the latest commit in the
-      # PR, but rather to the merge commit inserted by the PR. So instead we
-      # have to get 'HEAD' from the PR event.
-      #
-      # One cannot use the number of commits
-      # (github.event.pull_request.commits) to find the start commit
-      # i.e. HEAD~N does not work, this breaks if there are merge commits.
-      - name: Run commitlint on commits
-        run: >-
-{%- raw %}
-          npx commitlint --from '${{ github.event.pull_request.base.sha }}'
-          --to '${{ github.event.pull_request.head.sha }}' --verbose
-{%- endraw +%}
-
       - name: Run commitlint on PR title
         run: >-
 {%- raw %}


### PR DESCRIPTION
Adding the same template for any pull request.
It is possible to add different templates, e.g. have different fields requested for fix and for feat, but that's pretty ugly, described in https://stackoverflow.com/questions/73771068/multiple-templates-for-pull-requests-on-github
So users must do couple clicks to navigate to their template, it's not possible to set the template based on the PR title prefix. So it is easier to just have one template and then rely on contributers common sense to decide how to fill in the template.

Also, removing commits check from commitlint and only keep PR title check. Only PR title because the description can use all benefits of md formatting and e.g. have lines longer than 72 symbols etc.