### PR TITLE
ci: fix python 2.7 CI tests by manually installing python2.7 package

### DIFF
--- a/playbooks/templates/.github/workflows/python-unit-test.yml
+++ b/playbooks/templates/.github/workflows/python-unit-test.yml
@@ -45,7 +45,14 @@ jobs:
         uses: {{ gha_checkout_action }}
 {%- raw %}
 
-      - name: Set up Python
+      - name: Set up Python 2.7
+        if: ${{ matrix.pyver_os.ver == '2.7' }}
+        run: |
+          set -euxo pipefail
+          sudo apt install -y python2.7
+
+      - name: Set up Python 3
+        if: ${{ matrix.pyver_os.ver != '2.7' }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver_os.ver }}


### PR DESCRIPTION
We use the setup-python github action.  This has dropped support for
python 2.7.  Instead, just manually install the python2.7 package.
