### PR TITLE
add ostree files common to every role

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ anything on github, add `-e lsr_dry_run=true` to the ansible-playbook command.
   git branch that will be used for the PR.  You probably don't want to change
   this unless you have some conflict.
 * `lsr_dry_run` - default `true` - use `false` to actually push and create PRs
+* `test_dir` - default none - if you specify this, the playbook will checkout
+  the role directories under this directory - by default, the playbook will
+  create and remove a tmpdir
+* `exclude_roles` - default none - you can specify a comma-delimited list of
+  roles to exclude from processing.  This is useful when you want to update
+  all roles *except* the given roles.
+* `include_roles` - default none - you can specify a comma-delimited list of
+  roles to include in processing, and all other roles will be excluded.  This
+  is useful when you want to update *only* the given roles, and exclude the
+  rest.  NOTE: `include_roles` currently only works with 1 role at a time.
+  You cannot currently specify a list of roles.
 
 ### Run it
 
@@ -154,13 +165,16 @@ Run it like this:
 
 ```
 ansible-playbook -vv -i inventory -e lsr_dry_run=false \
+  -e update_files_branch=my_update_branch -e exclude_roles=nbde_client \
+  -e test_dir=/var/tmp/lsr \
   -e update_files_commit_file=/path/to/git-commit-msg playbooks/update_files.yml
 ```
 
 ### How it works
 
-* A temp directory is created
-* All of the roles are cloned into that directory
+* A temp directory is created if `test_dir` is not specified
+* All of the roles are cloned into that directory, except for the roles
+  listed in `exclude_roles`
 * Figure out the name of the main branch
 * If the branch `update_files_branch` does not exist, it is
   created from the main branch

--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -4,6 +4,9 @@ present_files:
   - .commitlintrc.js
   - .markdownlint.yaml
   - .pandoc_template.html5
+  - .ostree/get_ostree_data.sh
+  - .ostree/README.md
+  - README-ostree.md
 present_templates:
   - .ansible-lint
   - .yamllint.yml

--- a/inventory/host_vars/ad_integration.yml
+++ b/inventory/host_vars/ad_integration.yml
@@ -2,6 +2,7 @@ ansible_lint:
   mock_modules:
     - win_domain_group
     - win_domain_user
+    - community.general.ini_file
 github_actions:
   weekly_ci:
     schedule:

--- a/playbooks/files/.ostree/README.md
+++ b/playbooks/files/.ostree/README.md
@@ -1,0 +1,3 @@
+*NOTE*: The `*.txt` files are used by `get_ostree_data.sh` to create the lists
+of packages, and to find other system roles used by this role.  DO NOT use them
+directly.

--- a/playbooks/files/.ostree/get_ostree_data.sh
+++ b/playbooks/files/.ostree/get_ostree_data.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ostree_dir="${OSTREE_DIR:-"$(dirname "$(realpath "$0")")"}"
+
+if [ -z "${4:-}" ] || [ "${1:-}" = help ] || [ "${1:-}" = -h ]; then
+    cat <<EOF
+Usage: $0 packages [runtime|testing] DISTRO-MAJOR[.MINOR] [json|yaml|raw|toml]
+The script will use the packages and roles files in $ostree_dir to
+construct the list of packages needed to build the ostree image.  The script
+will output the list of packages in the given format
+- json is a JSON list like ["pkg1","pkg2",....,"pkgN"]
+- yaml is the YAML list format
+- raw is the list of packages, one per line
+- toml is a list of [[packages]] elements as in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index#creating-an-image-builder-blueprint-for-a-rhel-for-edge-image-using-the-command-line-interface_composing-a-rhel-for-edge-image-using-image-builder-command-line
+The DISTRO-MAJOR.MINOR is the same format used by Ansible for distribution e.g. CentOS-8, RedHat-8.9, etc.
+EOF
+    exit 1
+fi
+category="$1"
+pkgtype="$2"
+distro_ver="$3"
+format="$4"
+pkgtypes=("$pkgtype")
+if [ "$pkgtype" = testing ]; then
+    pkgtypes+=(runtime)
+fi
+
+get_rolepath() {
+    local ostree_dir role rolesdir roles_parent_dir coll_path path
+    ostree_dir="$1"
+    role="$2"
+    roles_parent_dir="$(dirname "$(dirname "$ostree_dir")")"
+    rolesdir="$roles_parent_dir/$role/.ostree"
+    # assumes collection format
+    if [ -d "$rolesdir" ]; then
+        echo "$rolesdir"
+        return 0
+    fi
+    # assumes legacy role format like linux-system-roles.$role/
+    for rolesdir in "$roles_parent_dir"/*-system-roles."$role"/.ostree; do
+        if [ -d "$rolesdir" ]; then
+          echo "$rolesdir"
+          return 0
+        fi
+    done
+    # look elsewhere
+    coll_path="${ANSIBLE_COLLECTIONS_PATH:-}"
+    if [ -z "$coll_path" ]; then
+        coll_path="${ANSIBLE_COLLECTIONS_PATHS:-}"
+    fi
+    if [ -n "${coll_path}" ]; then
+        for path in ${coll_path//:/ }; do
+            for rolesdir in "$path"/ansible_collections/*/*_system_roles/roles/"$role"/.ostree; do
+                if [ -d "$rolesdir" ]; then
+                    echo "$rolesdir"
+                    return 0
+                fi
+            done
+        done
+    fi
+    1>&2 echo ERROR - could not find role "$role" - please use ANSIBLE_COLLECTIONS_PATH
+    exit 2
+}
+
+get_packages() {
+    local ostree_dir pkgtype pkgfile rolefile
+    ostree_dir="$1"
+    for pkgtype in "${pkgtypes[@]}"; do
+        for suff in "" "-$distro" "-${distro}-${major_ver}" "-${distro}-${ver}"; do
+            pkgfile="$ostree_dir/packages-${pkgtype}${suff}.txt"
+            if [ -f "$pkgfile" ]; then
+                cat "$pkgfile"
+            fi
+        done
+        rolefile="$ostree_dir/roles-${pkgtype}.txt"
+        if [ -f "$rolefile" ]; then
+            local roles role rolepath
+            roles="$(cat "$rolefile")"
+            for role in $roles; do
+                rolepath="$(get_rolepath "$ostree_dir" "$role")"
+                if [ -z "$rolepath" ]; then
+                    1>&2 echo ERROR - could not find role "$role" - please use ANSIBLE_COLLECTIONS_PATH
+                    exit 2
+                fi
+                get_packages "$rolepath"
+            done
+        fi
+    done | sort -u
+}
+
+format_packages_json() {
+    local comma pkgs pkg
+    comma=""
+    pkgs="["
+    while read -r pkg; do
+        pkgs="${pkgs}${comma}\"${pkg}\""
+        comma=,
+    done
+    pkgs="${pkgs}]"
+    echo "$pkgs"
+}
+
+format_packages_raw() {
+    cat
+}
+
+format_packages_yaml() {
+    while read -r pkg; do
+        echo "- $pkg"
+    done
+}
+
+format_packages_toml() {
+    while read -r pkg; do
+        echo "[[packages]]"
+        echo "name = \"$pkg\""
+        echo "version = \"*\""
+    done
+}
+
+distro="${distro_ver%%-*}"
+ver="${distro_ver##*-}"
+if [[ "$ver" =~ ^([0-9]*) ]]; then
+    major_ver="${BASH_REMATCH[1]}"
+else
+    echo ERROR: cannot parse major version number from version "$ver"
+    exit 1
+fi
+
+"get_$category" "$ostree_dir" | "format_${category}_$format"

--- a/playbooks/files/README-ostree.md
+++ b/playbooks/files/README-ostree.md
@@ -1,0 +1,66 @@
+# rpm-ostree
+
+The role supports running on [rpm-ostree](https://coreos.github.io/rpm-ostree/)
+systems. The primary issue is that the `/usr` filesystem is read-only, and the
+role cannot install packages. Instead, it will just verify that the necessary
+packages and any other `/usr` files are pre-installed. The role will change the
+package manager to one that is compatible with `rpm-ostree` systems.
+
+## Building
+
+To build an ostree image for a particular operating system distribution and
+version, use the script `.ostree/get_ostree_data.sh` to get the list of
+packages. If the role uses other system roles, then the script will include the
+packages for the other roles in the list it outputs.  The list of packages will
+be sorted in alphanumeric order.
+
+Usage:
+
+```bash
+.ostree/get_ostree_data.sh packages runtime DISTRO-VERSION FORMAT
+```
+
+`DISTRO-VERSION` is in the format that Ansible uses for `ansible_distribution`
+and `ansible_distribution_version` - for example, `Fedora-38`, `CentOS-8`,
+`RedHat-9.4`
+
+`FORMAT` is one of `toml`, `json`, `yaml`, `raw`
+
+* `toml` - each package in a TOML `[[packages]]` element
+
+```toml
+[[packages]]
+name = "package-a"
+version = "*"
+[[packages]]
+name = "package-b"
+version = "*"
+...
+```
+
+* `yaml` - a YAML list of packages
+
+```yaml
+- package-a
+- package-b
+...
+```
+
+* `json` - a JSON list of packages
+
+```json
+["package-a","package-b",...]
+```
+
+* `raw` - a plain text list of packages, one per line
+
+```bash
+package-a
+package-b
+...
+```
+
+What format you choose depends on which image builder you are using.  For
+example, if you are using something based on
+[osbuild-composer](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index#creating-an-image-builder-blueprint-for-a-rhel-for-edge-image-using-the-command-line-interface_composing-a-rhel-for-edge-image-using-image-builder-command-line),
+you will probably want to use the `toml` output format.

--- a/playbooks/templates/.github/workflows/weekly_ci.yml
+++ b/playbooks/templates/.github/workflows/weekly_ci.yml
@@ -52,7 +52,7 @@ jobs:
           git push -f --set-upstream origin ${{ env.BRANCH_NAME }}
 
       - name: Create and comment pull request
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_PUSH_TOKEN }}
           script: |

--- a/playbooks/update_files.yml
+++ b/playbooks/update_files.yml
@@ -1,5 +1,11 @@
 - name: Manage files in system roles repos
-  hosts: active_roles
+  # NOTE: include_roles currently only works with 1 role - need to figure out
+  # how to pass in a list of include roles
+  hosts: active_roles{{
+    include_roles | split(",") | map("regex_replace", "^", ":&") | join("")
+    if include_roles | d(false) else "" }}{{
+    exclude_roles | split(",") | map("regex_replace", "^", ":!") | join("")
+    if exclude_roles | d(false) else "" }}
   connection: local
   gather_facts: false
   vars:
@@ -178,6 +184,22 @@
               {% endfor %}"
           vars:
             basenames: "{{ find.files | map(attribute='path') | map('basename') | sort | list }}"
+
+        - name: Remove get_ostree_data.sh from .sanity files
+          shell:
+            chdir: "{{ git_dir }}"
+            cmd: |
+              set -euxo pipefail
+              for file in .sanity-*.txt; do
+                if [ -f "$file" ] ; then
+                  sed '/get_ostree_data.sh.*shebang/d' -i "$file"
+                  if [ -s "$file" ]; then
+                    git add "$file"
+                  else
+                    git rm -f "$file"
+                  fi
+                fi
+              done
 
         - name: Create git commit, PR
           changed_when: false


### PR DESCRIPTION
add ostree files common to every role
ensure no get_ostree_data.sh shebang in ansible-test ignore files
update github script to version 7
document more parameters
add ability to include and exclude roles from processing

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
