### PR TITLE
ci: run ansible-lint against the collection

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -53,4 +53,4 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v4
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.1.1"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"

--- a/inventory/host_vars/ad_integration.yml
+++ b/inventory/host_vars/ad_integration.yml
@@ -3,6 +3,8 @@ ansible_lint:
     - win_domain_group
     - win_domain_user
     - community.general.ini_file
+    - ansible.windows.win_command
+    - ansible.windows.win_shell
 github_actions:
   weekly_ci:
     schedule:

--- a/inventory/host_vars/ha_cluster.yml
+++ b/inventory/host_vars/ha_cluster.yml
@@ -7,3 +7,10 @@ github_actions:
       - cron: "8 1 * * 4"
 role_present_templates:
   - .github/workflows/python-unit-test.yml
+# some ha_cluster code uses mypy - ansible-test does not like it
+# so we have to use compile-2.7!skip and import-x.y!skip - but
+# ansible-lint does not like that - so have to tell ansible-lint
+# to shut up
+ansible_lint:
+  skip_list:
+    - sanity[cannot-ignore]

--- a/inventory/host_vars/mssql.yml
+++ b/inventory/host_vars/mssql.yml
@@ -6,3 +6,5 @@ ansible_lint:
   skip_list:
     - galaxy[no-changelog]
     - galaxy[no-runtime]
+  mock_modules:
+    - ansible.windows.win_shell

--- a/inventory/host_vars/rhc.yml
+++ b/inventory/host_vars/rhc.yml
@@ -2,3 +2,6 @@ github_actions:
   weekly_ci:
     schedule:
       - cron: "0 19 * * 6"
+ansible_lint:
+  mock_modules:
+    - containers.podman.podman_container

--- a/inventory/host_vars/selinux.yml
+++ b/inventory/host_vars/selinux.yml
@@ -7,5 +7,7 @@ github_actions:
       - cron: "37 4 * * 4"
 ansible_lint:
   mock_modules:
-    - sefcontext
-    - selogin
+    - community.general.sefcontext
+    - community.general.selogin
+    - seboolean
+    - selinux

--- a/inventory/host_vars/timesync.yml
+++ b/inventory/host_vars/timesync.yml
@@ -2,6 +2,11 @@ github_actions:
   weekly_ci:
     schedule:
       - cron: "0 2 * * 0"
+# ansible-test does not like that we use a shell script as a module
+# so we have to add ignores for that - but ansible-lint does not like
+# ignores
 ansible_lint:
+  skip_list:
+    - sanity[cannot-ignore]
   extra_vars:
     targets: target_hosts

--- a/inventory/host_vars/tlog.yml
+++ b/inventory/host_vars/tlog.yml
@@ -4,4 +4,4 @@ github_actions:
       - cron: "0 3 * * 0"
 ansible_lint:
   mock_modules:
-    - ini_file
+    - community.general.ini_file

--- a/inventory/host_vars/vpn.yml
+++ b/inventory/host_vars/vpn.yml
@@ -5,3 +5,6 @@ github_actions:
   codeql:
     schedule:
       - cron: "8 10 * * 3"
+ansible_lint:
+  skip_list:
+    - sanity[cannot-ignore]

--- a/playbooks/files/.markdownlint.yaml
+++ b/playbooks/files/.markdownlint.yaml
@@ -1,3 +1,4 @@
+---
 # Default state for all rules
 default: true
 

--- a/playbooks/templates/.github/workflows/ansible-lint.yml
+++ b/playbooks/templates/.github/workflows/ansible-lint.yml
@@ -11,6 +11,9 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
   workflow_dispatch:
+env:
+  LSR_ROLE2COLL_NAMESPACE: {{ lsr_namespace }}
+  LSR_ROLE2COLL_NAME: {{ lsr_name }}
 permissions:
   contents: read
 jobs:
@@ -26,18 +29,23 @@ jobs:
       - name: Checkout repo
         uses: {{ gha_checkout_action }}
 
-      - name: Fix up role meta/main.yml namespace and name
+      - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          mm=meta/main.yml
-          if [ -f "$mm" ]; then
-            if ! grep -q '^  *namespace:' "$mm"; then
-              sed "/galaxy_info:/a\  namespace: {{ lsr_role_namespace }}" -i "$mm"
-            fi
-            if ! grep -q '^  *role_name:' "$mm"; then
-              sed "/galaxy_info:/a\  role_name: {{ inventory_hostname }}" -i "$mm"
-            fi
-          fi
+          pip3 install "{{ tox_lsr_url }}"
+
+      - name: Convert role to collection format
+        run: |
+          set -euxo pipefail
+          TOXENV=collection lsr_ci_runtox
+          coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+          # ansible-lint action requires a .git directory???
+          # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
+          mkdir -p "$coll_dir/.git"
 
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@v6
+        uses: ansible/ansible-lint@v6
+        with:
+{%- raw %}
+          working_directory: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
+{%- endraw +%}

--- a/playbooks/templates/.github/workflows/ansible-test.yml
+++ b/playbooks/templates/.github/workflows/ansible-test.yml
@@ -38,23 +38,7 @@ jobs:
       - name: Convert role to collection format
         run: |
           set -euxo pipefail
-          # Remove to avoid running ansible-test on unrelated file
-          rm -f .pandoc_template.html5
           TOXENV=collection lsr_ci_runtox
-          # copy the ignore files
-          coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
-          # wokeignore:rule=sanity
-          ignore_dir="$coll_dir/tests/sanity"
-          if [ ! -d "$ignore_dir" ]; then
-            mkdir -p "$ignore_dir"
-          fi
-          # wokeignore:rule=sanity
-          for file in .sanity-ansible-ignore-*.txt; do
-            if [ -f "$file" ]; then
-              # wokeignore:rule=sanity
-              cp "$file" "$ignore_dir/${file//*.sanity-ansible-}"
-            fi
-          done
 
       - name: Run ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1

--- a/playbooks/templates/.github/workflows/codeql.yml
+++ b/playbooks/templates/.github/workflows/codeql.yml
@@ -34,17 +34,17 @@ jobs:
         uses: {{ gha_checkout_action }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
 {%- raw %}
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
 {%- endraw +%}

--- a/playbooks/templates/.github/workflows/python-unit-test.yml
+++ b/playbooks/templates/.github/workflows/python-unit-test.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Set up Python 3
         if: ${{ matrix.pyver_os.ver != '2.7' }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.pyver_os.ver }}
 


### PR DESCRIPTION
The latest Ansible repo gating tests run ansible-lint against
the collection format instead of against individual roles.
We have to convert the role to collection format before running
ansible-test.

Role developers can run this locally using
`tox -e collection,ansible-lint-collection`
See https://github.com/linux-system-roles/tox-lsr/pull/125

ha_cluster - add to python_roles

metrics - fix ansible-lint

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
