### PR TITLE
add wokeignore rule for ansible-lint sanity skip

### DIFF
--- a/inventory/host_vars/ha_cluster.yml
+++ b/inventory/host_vars/ha_cluster.yml
@@ -13,4 +13,4 @@ role_present_templates:
 # to shut up
 ansible_lint:
   skip_list:
-    - sanity[cannot-ignore]
+    - sanity[cannot-ignore]  # wokeignore:rule=sanity

--- a/inventory/host_vars/timesync.yml
+++ b/inventory/host_vars/timesync.yml
@@ -7,6 +7,6 @@ github_actions:
 # ignores
 ansible_lint:
   skip_list:
-    - sanity[cannot-ignore]
+    - sanity[cannot-ignore]  # wokeignore:rule=sanity
   extra_vars:
     targets: target_hosts

--- a/inventory/host_vars/vpn.yml
+++ b/inventory/host_vars/vpn.yml
@@ -7,4 +7,4 @@ github_actions:
       - cron: "8 10 * * 3"
 ansible_lint:
   skip_list:
-    - sanity[cannot-ignore]
+    - sanity[cannot-ignore]  # wokeignore:rule=sanity


### PR DESCRIPTION
add wokeignore for .ansible-lint sanity skips
