### PR TITLE
Use tox-lsr 3.2.2

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -53,4 +53,4 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v4
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"

--- a/playbooks/templates/.ansible-lint
+++ b/playbooks/templates/.ansible-lint
@@ -24,7 +24,10 @@ kinds:
 {%   set val = (default_ansible_lint | d({})).get(param, []) + (ansible_lint | d({})).get(param, []) %}
 {%   if val %}
 {{ param }}:
-{{ val | to_nice_yaml(indent=2) | indent(width=2, first=true) -}}
+{%     for item in val %}
+  - {{ item }}{% if item is search("sanity") %}  # wokeignore:rule=sanity{% endif %}
+
+{%     endfor %}
 {%   endif %}
 {% endfor %}
 {# dict valued params #}


### PR DESCRIPTION
Use tox-lsr 3.2.2
Allow comments inline in .ansible-lint for wokeignore
