### PR TITLE
ci: ansible-lint action now requires absolute directory

### DIFF
--- a/playbooks/templates/.github/workflows/ansible-lint.yml
+++ b/playbooks/templates/.github/workflows/ansible-lint.yml
@@ -47,5 +47,5 @@ jobs:
         uses: ansible/ansible-lint@v24
         with:
 {%- raw %}
-          working_directory: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
+          working_directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
 {%- endraw +%}

--- a/playbooks/templates/.github/workflows/ansible-test.yml
+++ b/playbooks/templates/.github/workflows/ansible-test.yml
@@ -45,5 +45,5 @@ jobs:
         with:
           testing-type: sanity  # wokeignore:rule=sanity
 {%- raw %}
-          collection-src-directory: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
+          collection-src-directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
 {%- endraw +%}


### PR DESCRIPTION
the change made for
https://github.com/ansible/ansible-lint/commit/b4018c22f8fe8371bd6845d0cd62cebea54ce012
means that ansible-lint now needs an absolute path for the working directory

Go ahead and make ansible-test use absolute path too just in case they decide
to make the same change.
