### PR TITLE
fix: add support for EL10

### DIFF
--- a/playbooks/update_files.yml
+++ b/playbooks/update_files.yml
@@ -65,6 +65,9 @@
             cmd: |
               set -euo pipefail
               cur_br=$(git branch --show-current)
+              if [ "$cur_br" = "{{ __main_br }}" ]; then
+                git pull
+              fi
               if [ "$cur_br" = {{ update_files_branch | quote }} ]; then
                 # assume this is in active development
                 exit 10
@@ -219,12 +222,40 @@
                 fi
               fi
 
+        - name: Create vars, ostree files for el10
+          shell:
+            chdir: "{{ git_dir }}"
+            cmd: |
+              set -euxo pipefail
+              set -- vars/CentOS_9.yml vars/CentOS_10.yml vars/RedHat_9.yml vars/RedHat_10.yml \
+                vars/CentOS-9.yml vars/CentOS-10.yml vars/RedHat-9.yml vars/RedHat-10.yml \
+                .ostree/packages-runtime-CentOS-9.txt .ostree/packages-runtime-CentOS-10.txt \
+                .ostree/packages-testing-CentOS-9.txt .ostree/packages-testing-CentOS-10.txt \
+                .ostree/packages-runtime-RedHat-9.txt .ostree/packages-runtime-RedHat-10.txt \
+                .ostree/packages-testing-RedHat-9.txt .ostree/packages-testing-RedHat-10.txt
+              while [ "${1:-}" ]; do
+                src="$1"; shift
+                dest="$1"; shift
+                if [ ! -f "$dest" ] && [ -f "$src" ]; then
+                  cp "$src" "$dest"
+                  git add "$dest"
+                fi
+              done
+
+        - name: Add el10 to meta/main.yml
+          script: scripts/update_meta_main.py {{ __meta_main | quote }}
+          args:
+            executable: python3
+          vars:
+            __meta_main: "{{ git_dir }}/meta/main.yml"
+
         - name: Create git commit, PR
           changed_when: false
           shell:
             chdir: "{{ git_dir }}"
             cmd: |
               set -euo pipefail
+              git add meta/main.yml
               for file in {{ __all_present | join(" ") }}; do
                   git add "$file"
               done


### PR DESCRIPTION
According to the Ansible team, support for listing platforms in
role `meta/main.yml` files is being removed.
Instead, they recommend using `galaxy_tags`

https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
"Remove the galaxy_info field platforms from the role templates"
https://github.com/ansible/ansible/issues/82453

Many roles already have tags such as "rhel", "redhat", "centos", and "fedora".
I propose that we ensure all of the system roles have these tags.
Some of our roles support Suse, Debian, Ubuntu, and others.
We should add tags for those e.g. the ssh role already has tags for "debian" and "ubuntu".

In addition - for each version listed under `platforms.EL` - add a tag like `elN`.

Q: Why not use a delimiter between the platform and the version e.g. `el-10`?

This is not allowed by ansible-lint:

```
meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'el-10'
meta/main.yml:1
```

So we cannot use uppercase letters either.

Q: Why not use our own meta/main.yml field?

No other fields are allowed by ansible-lint:

```
syntax-check[specific]: 'myfield' is not a valid attribute for a RoleMetadata
```

Q: Why not use some other field?

There are no other applicable or suitable fields.

Q: What happens when we want to support versions like `N.M`?

Use the word "dot" instead of "." e.g. `el10dot3`.
Similarly - use "dash" instead of "-".

We do not need tags such as `fedoraall`.
The `fedora` tag implies that the role works on all supported versions of fedora.
Otherwise, use tags such as `fedora40` if the role only supports specific versions.

In addition - for roles that have different variable files for EL9, create
the corresponding EL10 files.
