### PR TITLE
ci: Add workflow for ci_test bad, use remote fmf plan

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -22,11 +22,10 @@ present_templates:
   - .github/workflows/pr-title-lint.yml
   - .github/workflows/test_converting_readme.yml
   - .github/workflows/tft.yml
+  - .github/workflows/tft_citest_bad.yml
   - .github/workflows/weekly_ci.yml
   - .github/workflows/woke.yml
   - README-ansible.md
-  - plans/general.fmf
-  - plans/README-plans.md
 absent_files:
   - .github/workflows/commitlint.yml
   - .github/workflows/tox.yml
@@ -39,6 +38,9 @@ absent_files:
   - .github/actions/custom-woke-action/testdata/bad.txt
   - .github/actions/custom-woke-action
   - .github/actions
+  - plans/README-plans.md
+  - plans/general.fmf
+  - plans
 github_org: linux-system-roles
 github_url_prefix: "https://github.com/"
 default_ansible_lint:

--- a/playbooks/templates/.github/workflows/tft.yml
+++ b/playbooks/templates/.github/workflows/tft.yml
@@ -1,3 +1,4 @@
+---
 name: Run integration tests in Testing Farm
 on:
   issue_comment:
@@ -7,15 +8,15 @@ permissions:
   contents: read
   # This is required for the ability to create/update the Pull request status
   statuses: write
-# The concurrency key is used to prevent multiple workflows from running at the same time
-concurrency:
-{%- raw %}
-  # group name contains reponame-pr_num to allow simualteneous runs in different PRs
-  group: testing-farm-${{ github.event.repository.name }}-${{ github.event.issue.number }}
-  cancel-in-progress: true
 jobs:
   prepare_vars:
     name: Get info from role and PR to determine if and how to test
+    # The concurrency key is used to prevent multiple workflows from running at the same time
+    concurrency:
+    {%- raw %}
+      # group name contains reponame-pr_num to allow simualteneous runs in different PRs
+      group: testing-farm-${{ github.event.repository.name }}-${{ github.event.issue.number }}
+      cancel-in-progress: true
     # Let's schedule tests only on user request. NOT automatically.
     # Only repository owner or member can schedule tests
     if: |
@@ -27,7 +28,6 @@ jobs:
     outputs:
       supported_platforms: ${{ steps.supported_platforms.outputs.supported_platforms }}
       head_sha: ${{ steps.head_sha.outputs.head_sha }}
-      datetime: ${{ steps.datetime.outputs.datetime }}
       memory: ${{ steps.memory.outputs.memory }}
     steps:
       - name: Dump github context
@@ -51,12 +51,6 @@ jobs:
           PR_NO: ${{ github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 {%- endraw +%}
-
-      - name: Get current datetime
-        id: datetime
-        run: |
-          printf -v datetime '%(%Y%m%d-%H%M%S)T' -1
-          echo "datetime=$datetime" >> $GITHUB_OUTPUT
 
       - name: Get memory
         id: memory
@@ -126,6 +120,19 @@ jobs:
         ${{ needs.prepare_vars.outputs.datetime }}/artifacts"
       ARTIFACT_TARGET_DIR: /srv/pub/alt/linuxsystemroles/logs
     steps:
+      - name: Set variables with DATETIME and artifact location
+        id: set_vars
+        run: |
+          printf -v DATETIME '%(%Y%m%d-%H%M%S)T' -1
+          ARTIFACTS_DIR_NAME="tf_${{ github.event.repository.name }}-${{ github.event.issue.number }}_\
+          ${{ matrix.platform }}-${{ matrix.ansible_version }}_$DATETIME/artifacts"
+          ARTIFACTS_TARGET_DIR=/srv/pub/alt/linuxsystemroles/logs
+          ARTIFACTS_DIR=$ARTIFACTS_TARGET_DIR/$ARTIFACTS_DIR_NAME
+          ARTIFACTS_URL=https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs$ARTIFACTS_DIR_NAME
+          echo "DATETIME=$DATETIME" >> $GITHUB_OUTPUT
+          echo "ARTIFACTS_DIR=$ARTIFACTS_DIR" >> $GITHUB_OUTPUT
+          echo "ARTIFACTS_URL=$ARTIFACTS_URL" >> $GITHUB_OUTPUT
+
       - name: Set commit status as pending
         if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
         uses: myrotvorets/set-commit-status-action@master
@@ -147,21 +154,19 @@ jobs:
           targetUrl: ""
 
       - name: Run test in testing farm
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@v3
         if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
-        env:
-          ARTIFACTS_DIR: ${{ env.ARTIFACT_TARGET_DIR }}/${{ env.ARTIFACTS_DIR_NAME }}
-          ARTIFACTS_URL: https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/${{ env.ARTIFACTS_DIR_NAME }}
         with:
-          git_url: ${{ github.server_url }}/${{ github.repository }}
-          git_ref: ${{ needs.prepare_vars.outputs.head_sha }}
+          git_url: https://github.com/linux-system-roles/tft-tests
+          git_ref: main
           pipeline_settings: '{ "type": "tmt-multihost" }'
           variables: "ANSIBLE_VER=${{ matrix.ansible_version }};\
             REPO_NAME=${{ github.event.repository.name }};\
+            GITHUB_ORG=${{ github.repository_owner }};\
             GITHUB_ORG=linux-system-roles;\
             PR_NUM=${{ github.event.issue.number }};\
-            ARTIFACTS_DIR=${{ env.ARTIFACTS_DIR }};\
-            ARTIFACTS_URL=${{ env.ARTIFACTS_URL }};\
+            ARTIFACTS_DIR=${{ steps.set_vars.outputs.ARTIFACTS_DIR }};\
+            ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }};\
             TEST_LOCAL_CHANGES=false"
           # Note that LINUXSYSTEMROLES_SSH_KEY must be single-line, TF doesn't read multi-line variables fine.
           secrets: "LINUXSYSTEMROLES_USER=${{ secrets.LINUXSYSTEMROLES_USER }};\
@@ -179,12 +184,10 @@ jobs:
       - name: Set final commit status
         uses: myrotvorets/set-commit-status-action@master
         if: always() && contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
-        env:
-          ARTIFACTS_URL: https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/${{ env.ARTIFACTS_DIR_NAME }}
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: ${{ job.status }}
           context: ${{ matrix.platform }}|ansible-${{ matrix.ansible_version }}
           description: Test finished
-          targetUrl: ${{ env.ARTIFACTS_URL }}
+          targetUrl: ${{ steps.set_vars.outputs.ARTIFACTS_URL }}
 {%- endraw +%}

--- a/playbooks/templates/.github/workflows/tft_citest_bad.yml
+++ b/playbooks/templates/.github/workflows/tft_citest_bad.yml
@@ -1,0 +1,45 @@
+---
+name: Re-run failed testing farm tests
+on:
+  issue_comment:
+    types:
+      - created
+permissions:
+  contents: read
+jobs:
+  citest_bad_rerun:
+    if: |
+      github.event.issue.pull_request
+      && github.event.comment.body == '[citest_bad]'
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association)
+    permissions:
+      actions: write # for re-running failed jobs: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#re-run-a-job-from-a-workflow-run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait 10s until tft.yml workflow is created and skipped because new comment don't match [citest]
+        run: sleep 10s
+
+      - name: Re-run failed jobs for this PR
+        env:
+{%- raw %}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_TITLE: ${{ github.event.issue.title }}
+{%- endraw +%}
+        run: |
+          PENDING_RUN=$(gh api "repos/$REPO/actions/workflows/tft.yml/runs?event=issue_comment" \
+            | jq -r "[.workflow_runs[] | select( .display_title == \"$PR_TITLE\") | \
+            select(.status == \"pending\" or .status == \"queued\" or .status == \"in_progress\") | .id][0]")
+          # if pending run don't exist, take the last run with failure state
+          if [ "$PENDING_RUN" != "null" ]; then
+            echo "The workflow $PENDING_RUN is still running, wait for it to finish to re-run"
+            exit 1
+          fi
+          RUN_ID=$(gh api "repos/$REPO/actions/workflows/tft.yml/runs?event=issue_comment" \
+            | jq -r "[.workflow_runs[] | select( .display_title == \"$PR_TITLE\" ) | select( .conclusion == \"failure\" ) | .id][0]")
+          if [ "$RUN_ID" = "null" ]; then
+            echo "Failed workflow not found, exitting"
+            exit 1
+          fi
+          echo "Re-running workflow $RUN_ID"
+          gh api --method POST repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs


### PR DESCRIPTION
* Remove plan from role dir, it's too complicated and long to run tests from tmt
* Use plan from linux-system-roles/tft-tests
* Move getting datetime to testing-farm job where it's used
* Add a workflow for running [citest_bad]
* Bump sclorg/testing-farm-as-github-action to v3
* Move concurrency group to first job
* Dump GitHub context