### PR TITLE
ci: ansible-test action now requires ansible-core version

### DIFF
--- a/inventory/host_vars/metrics.yml
+++ b/inventory/host_vars/metrics.yml
@@ -12,7 +12,7 @@ ansible_lint:
     - performancecopilot.metrics.mssql
     - performancecopilot.metrics.pcp
     - performancecopilot.metrics.postfix
-    - performancecopilot.metrics.redis
+    - performancecopilot.metrics.keyserver
     - performancecopilot.metrics.repository
     - performancecopilot.metrics.spark
 markdownlint_args: "--ignore=vendor --ignore=tests/roles"

--- a/playbooks/templates/.github/workflows/ansible-test.yml
+++ b/playbooks/templates/.github/workflows/ansible-test.yml
@@ -44,6 +44,7 @@ jobs:
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
           testing-type: sanity  # wokeignore:rule=sanity
+          ansible-core-version: stable-2.17
 {%- raw %}
           collection-src-directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
 {%- endraw +%}


### PR DESCRIPTION
The ansible-test github action does not use a supported version
of ansible-core by default.
https://github.com/ansible-community/ansible-test-gh-action?tab=readme-ov-file#ansible-core-version

We have to set it in our action.  Using `stable-2.17` as that is the latest stable version.
