### PR TITLE
Remove mock_modules from mssql

### DIFF
--- a/inventory/host_vars/mssql.yml
+++ b/inventory/host_vars/mssql.yml
@@ -6,5 +6,3 @@ ansible_lint:
   skip_list:
     - galaxy[no-changelog]
     - galaxy[no-runtime]
-  mock_modules:
-    - ansible.windows.win_shell


### PR DESCRIPTION
win_shell is not used in the role since it's #301