### PR TITLE
ci: ansible-plugin-scan is disabled for now

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -14,7 +14,6 @@ present_templates:
   - contributing.md
   - .github/workflows/ansible-lint.yml
   - .github/workflows/ansible-managed-var-comment.yml
-  - .github/workflows/ansible-plugin-scan.yml
   - .github/workflows/ansible-test.yml
   - .github/workflows/build_docs.yml
   - .github/workflows/changelog_to_tag.yml
@@ -28,6 +27,7 @@ present_templates:
   - README-ansible.md
   - tests/vars/rh_distros_vars.yml
 absent_files:
+  - .github/workflows/ansible-plugin-scan.yml
   - .github/workflows/commitlint.yml
   - .github/workflows/tox.yml
   - README-devel.md


### PR DESCRIPTION
ansible-plugin-scan is broken due to lack of support for older versions
of python in ci.
One of the main reasons for using this scan is to check if the roles/tests
are using plugins that are not compatible with ansible 2.9.  Since 2.9
is EOL, this is no longer necessary.
The other reason for using the scan is to check that the role/test
author has correctly listed dependencies in meta/collection-requirements.yml
and tests/collection-requirements.yml - that is - that the author has
correctly specified the dependencies for any plugins used that are
not built-in.  This will mostly be caught in CI testing now.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
