### PR TITLE
ci: bump ansible-lint to v25; provide collection requirements for ansible-lint

### DIFF
--- a/inventory/host_vars/ad_integration.yml
+++ b/inventory/host_vars/ad_integration.yml
@@ -2,9 +2,6 @@ ansible_lint:
   mock_modules:
     - win_domain_group
     - win_domain_user
-    - community.general.ini_file
-    - ansible.windows.win_command
-    - ansible.windows.win_shell
 github_actions:
   weekly_ci:
     schedule:

--- a/inventory/host_vars/rhc.yml
+++ b/inventory/host_vars/rhc.yml
@@ -2,6 +2,3 @@ github_actions:
   weekly_ci:
     schedule:
       - cron: "0 19 * * 6"
-ansible_lint:
-  mock_modules:
-    - containers.podman.podman_container

--- a/inventory/host_vars/selinux.yml
+++ b/inventory/host_vars/selinux.yml
@@ -7,7 +7,5 @@ github_actions:
       - cron: "37 4 * * 4"
 ansible_lint:
   mock_modules:
-    - community.general.sefcontext
-    - community.general.selogin
     - seboolean
     - selinux

--- a/inventory/host_vars/tlog.yml
+++ b/inventory/host_vars/tlog.yml
@@ -2,6 +2,3 @@ github_actions:
   weekly_ci:
     schedule:
       - cron: "0 3 * * 0"
-ansible_lint:
-  mock_modules:
-    - community.general.ini_file

--- a/playbooks/templates/.github/workflows/ansible-lint.yml
+++ b/playbooks/templates/.github/workflows/ansible-lint.yml
@@ -35,17 +35,52 @@ jobs:
           pip3 install "{{ tox_lsr_url }}"
 
       - name: Convert role to collection format
+        id: collection
         run: |
           set -euxo pipefail
           TOXENV=collection lsr_ci_runtox
           coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+          # cleanup after collection conversion
+          rm -rf "$coll_dir/.ansible" .tox/ansible-plugin-scan
           # ansible-lint action requires a .git directory???
           # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
           mkdir -p "$coll_dir/.git"
+{%- raw %}
+          meta_req_file="${{ github.workspace }}/meta/collection-requirements.yml"
+          test_req_file="${{ github.workspace }}/tests/collection-requirements.yml"
+          if [ -f "$meta_req_file" ] && [ -f "$test_req_file" ]; then
+            coll_req_file="${{ github.workspace }}/req.yml"
+{%- endraw +%}
+            python -c 'import sys; import yaml
+          hsh1 = yaml.safe_load(open(sys.argv[1]))
+          hsh2 = yaml.safe_load(open(sys.argv[2]))
+          coll = {}
+          for item in hsh1["collections"] + hsh2["collections"]:
+            if isinstance(item, dict):
+              name = item["name"]
+              rec = item
+            else:
+              name = item  # assume string
+              rec = {"name": name}
+            if name not in coll:
+              coll[name] = rec
+          hsh1["collections"] = list(coll.values())
+          yaml.safe_dump(hsh1, open(sys.argv[3], "w"))' "$meta_req_file" "$test_req_file" "$coll_req_file"
+            echo merged "$coll_req_file"
+            cat "$coll_req_file"
+          elif [ -f "$meta_req_file" ]; then
+            coll_req_file="$meta_req_file"
+          elif [ -f "$test_req_file" ]; then
+            coll_req_file="$test_req_file"
+          else
+            coll_req_file=""
+          fi
+          echo "coll_req_file=$coll_req_file" >> $GITHUB_OUTPUT
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v24
+        uses: ansible/ansible-lint@v25
         with:
 {%- raw %}
           working_directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
+          requirements_file: ${{ steps.collection.outputs.coll_req_file }}
 {%- endraw +%}

--- a/playbooks/update_files.yml
+++ b/playbooks/update_files.yml
@@ -63,7 +63,8 @@
           shell:
             chdir: "{{ git_dir }}"
             cmd: |
-              set -euo pipefail
+              set -euxo pipefail
+              exec 1>&2
               cur_br=$(git branch --show-current)
               if [ "$cur_br" = "{{ __main_br }}" ]; then
                 git pull
@@ -73,7 +74,7 @@
                 exit 10
               elif git checkout {{ update_files_branch | quote }} > /dev/null 2>&1; then
                 git rebase "{{ __main_br }}"
-                git reset --soft HEAD^
+                git reset --soft "{{ __main_br }}"
                 exit 10
               else
                 git checkout -b {{ update_files_branch | quote }}
@@ -318,13 +319,7 @@
               fi
               commit_file={{ update_files_commit_file | quote }}
               branch={{ update_files_branch | quote }}
-              if [ "{{ __is_new | ternary('true', 'false') }}" = true ]; then
-                git commit -s -F "$commit_file"
-              else
-                # commit orig head, then amend, and ensure commit is signed
-                git commit -C ORIG_HEAD
-                git commit -s --amend -F "$commit_file"
-              fi
+              git commit -s -F "$commit_file"
               force_flag="{{ __is_new | ternary('', '-f') }}"
               if [ {{ lsr_dry_run | d('true') }} = false ]; then
                 git push $force_flag -u origin "$branch"


### PR DESCRIPTION
There is a new version of ansible-lint - v25.
Newer versions of ansible-lint require the collection requirements to be
installed so it can find the modules/plugins.
Enhance our ansible-lint ci job to provide the collection requirements,
including merging the runtime meta/collection-requirements.yml with
the testing tests/collection-requirements.yml.
This should somewhat mitigate the loss of ansible-plugin-scan.
We have to remove mock_modules that are actually present now.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
