### PR TITLE
ci: Check spelling with codespell

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -10,6 +10,7 @@ present_files:
   - README-ostree.md
 present_templates:
   - .ansible-lint
+  - .codespellrc
   - .yamllint.yml
   - contributing.md
   - .github/workflows/ansible-lint.yml
@@ -17,6 +18,7 @@ present_templates:
   - .github/workflows/ansible-test.yml
   - .github/workflows/build_docs.yml
   - .github/workflows/changelog_to_tag.yml
+  - .github/workflows/codespell.yml
   - .github/workflows/markdownlint.yml
   - .github/workflows/pr-title-lint.yml
   - .github/workflows/test_converting_readme.yml

--- a/inventory/host_vars/aide.yml
+++ b/inventory/host_vars/aide.yml
@@ -1,0 +1,4 @@
+github_actions:
+  weekly_ci:
+    schedule:
+      - cron: "0 11 * * 6"

--- a/inventory/host_vars/metrics.yml
+++ b/inventory/host_vars/metrics.yml
@@ -16,3 +16,5 @@ ansible_lint:
     - performancecopilot.metrics.repository
     - performancecopilot.metrics.spark
 markdownlint_args: "--ignore=vendor --ignore=tests/roles"
+codespell_skip:
+  - vendor

--- a/inventory/host_vars/network.yml
+++ b/inventory/host_vars/network.yml
@@ -18,3 +18,6 @@ present_badges:
   - "[![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)"
   - "[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/linux-system-roles/network.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/linux-system-roles/network/context:python)"
 lsr_rh_distros_extra: [OracleLinux]
+codespell_skip:
+  - ./tests/files/client.key.nocrypt
+  - ./tests/files/client.pem

--- a/playbooks/include_files/storage_contributing.md
+++ b/playbooks/include_files/storage_contributing.md
@@ -11,7 +11,7 @@ imports are located at `module_utils/storage_lsr`.
 ### Defaults
 
 This is where we define the structure of the vars available to users to specify
-how they want the storage to be layed out. There are two top-level lists:
+how they want the storage to be laid out. There are two top-level lists:
 `storage_pools` is a list of pools, which contain volumes, and
 `storage_volumes`, which are volumes that are not associated with any pool.
 Examples of pools include LVM volume groups and disks with partition tables.

--- a/playbooks/templates/.codespellrc
+++ b/playbooks/templates/.codespellrc
@@ -1,0 +1,15 @@
+[codespell]
+check-hidden = true
+# Note that `-w` doesn't work when ignore-multiline-regex is set
+# https://github.com/codespell-project/codespell/issues/3642
+ignore-multiline-regex = codespell:ignore-begin.*codespell:ignore-end
+ignore-words = .codespell_ignores
+# skip-file is not available https://github.com/codespell-project/codespell/pull/2759
+# .pandoc_template.html5 contains a typo in Licence that we shouldn't edit
+# .README.html is generated from README.md automatically - no need to check spelling
+skip = .pandoc_template.html5,.README.html
+{%- if codespell_skip is defined -%}
+{%- for item in (codespell_skip | d([])) -%}
+,{{ item }}
+{%- endfor -%}
+{%- endif +%}

--- a/playbooks/templates/.github/workflows/codespell.yml
+++ b/playbooks/templates/.github/workflows/codespell.yml
@@ -1,0 +1,17 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+permissions:
+  contents: read
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: {{ gha_checkout_action }}
+
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/playbooks/templates/.github/workflows/tft_citest_bad.yml
+++ b/playbooks/templates/.github/workflows/tft_citest_bad.yml
@@ -38,7 +38,7 @@ jobs:
           RUN_ID=$(gh api "repos/$REPO/actions/workflows/tft.yml/runs?event=issue_comment" \
             | jq -r "[.workflow_runs[] | select( .display_title == \"$PR_TITLE\" ) | select( .conclusion == \"failure\" ) | .id][0]")
           if [ "$RUN_ID" = "null" ]; then
-            echo "Failed workflow not found, exitting"
+            echo "Failed workflow not found, exiting"
             exit 1
           fi
           echo "Re-running workflow $RUN_ID"

--- a/playbooks/update_files.yml
+++ b/playbooks/update_files.yml
@@ -139,6 +139,20 @@
           loop: "{{ present_files + __present_python_files +
             __present_shellcheck_files }}"
 
+        - name: Process files to be removed
+          shell:
+            chdir: "{{ git_dir }}"
+            cmd: |
+              set -euo pipefail
+              if [ ! -f {{ item }} ]; then
+                echo WARNING: file to be deleted was not found: {{ item }}
+              else
+                git rm -f {{ item }}
+              fi
+          register: git_rm
+          changed_when: "'rm ' in git_rm.stdout"
+          loop: "{{ __all_absent }}"
+
         # NOTE: Some of the templates are github action definitions
         # which use ${{ var }} - you may have to put {%- raw %}
         # {%- endraw +%} blocks around them.
@@ -294,6 +308,19 @@
             path: "{{ 'vars/main.yml' if __vars_main.stat.exists
               else 'defaults/main.yml' }}"
 
+        - name: Create an empty .codespell_ignores file if it doesn't exist
+          shell:
+            chdir: "{{ git_dir }}"
+            cmd: |
+              set -euo pipefail
+              if [ ! -f .codespell_ignores ]; then
+                touch .codespell_ignores
+                git add .codespell_ignores
+                echo Success
+               fi
+          register: codespell_ignores
+          changed_when: "'Success' in codespell_ignores.stdout"
+
         - name: Create git commit, PR
           changed_when: false
           shell:
@@ -305,13 +332,6 @@
                   git add "$file"
               done
               git add README.md
-              for file in {{ __all_absent | join(" ") }}; do
-                  if [ ! -f "$file" ]; then
-                    echo WARNING: file to be deleted was not found: "$file"
-                  else
-                    git rm -f "$file"
-                  fi
-              done
               if git diff --cached --quiet; then
                 # nothing to do
                 echo No updates for role {{ inventory_hostname }}


### PR DESCRIPTION
* You can ignore words inline by adding a comment like `# codespell:ignore word`.
* You can ignore words by adding them to the `.codespell_ignores` file.
* You can ignore files and directories by adding them with `skip = ` to the `.codespellrc` file.
