### PR TITLE
ci: Bump Ubuntu version for Python unit tests

### DIFF
--- a/playbooks/templates/.github/workflows/python-unit-test.yml
+++ b/playbooks/templates/.github/workflows/python-unit-test.yml
@@ -20,9 +20,7 @@ jobs:
       matrix:
         pyver_os:
           - ver: "2.7"
-            os: ubuntu-20.04
-          - ver: "3.6"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - ver: "3.8"
             os: ubuntu-latest
           - ver: "3.9"


### PR DESCRIPTION
Ubuntu 20.04 will be removed from GH actions by April 1, 2025. We can switch to 22.04 which still has Python 2.