### PR TITLE
ci: Remove tft trigger capability for contributors

### DIFF
--- a/playbooks/templates/.github/workflows/tft.yml
+++ b/playbooks/templates/.github/workflows/tft.yml
@@ -22,7 +22,7 @@ jobs:
     if: |
       github.event.issue.pull_request
       && contains(github.event.comment.body, '[citest]')
-      && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association)
+      && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       || contains('systemroller', github.event.comment.user.login))
     runs-on: ubuntu-latest
     outputs:

--- a/playbooks/templates/.github/workflows/tft_citest_bad.yml
+++ b/playbooks/templates/.github/workflows/tft_citest_bad.yml
@@ -11,7 +11,7 @@ jobs:
     if: |
       github.event.issue.pull_request
       && contains(fromJson('["[citest_bad]", "[citest-bad]", "[citest bad]"]'), github.event.comment.body)
-      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association)
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     permissions:
       actions: write # for re-running failed jobs: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#re-run-a-job-from-a-workflow-run
     runs-on: ubuntu-latest


### PR DESCRIPTION
The tft jobs run inside the RH internal network, and thus have access to a lot of sensitive data. It is very easy to gain "contributor" status in GitHub, you just need to land a single commit (like a typo fix or small doc update), and it is hard to get a list of/control the set of contributors.

Thus restrict the trigger capability to org members and collaborators, which are an explicit list and much easier to control.

---

This isn't an "obvious" choice. If you get lots of drive-by contributions, I recommend to apply this, as it's too much of a risk. If you have a small set of non-org people who send updates regularly, I recommend to put them into the list on https://github.com/linux-system-roles/.github/settings/access . But the situation may be different for you, so please absolutely feel free to close this as "this is intentional and we want this".