### PR TITLE
Apply a stricter policy to who can run the workflow

### DIFF
--- a/playbooks/templates/.github/workflows/tft.yml
+++ b/playbooks/templates/.github/workflows/tft.yml
@@ -22,7 +22,7 @@ jobs:
     if: |
       github.event.issue.pull_request
       && contains(github.event.comment.body, '[citest]')
-      && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association)
+      && (contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
       || contains('systemroller', github.event.comment.user.login))
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
Martin pointed out that it would be safer to restrict this to Owner and Member so that we have full control over who can run the workflow. Otherwise any person who's PR was ever merged can run it.