### PR TITLE
ci: Bump tox-lsr to 3.5.1

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -61,5 +61,5 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v4
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.5.0"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.5.1"
 lsr_rh_distros: "{{ ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky'] + lsr_rh_distros_extra | d([]) }}"

--- a/playbooks/templates/.github/workflows/python-unit-test.yml
+++ b/playbooks/templates/.github/workflows/python-unit-test.yml
@@ -105,5 +105,5 @@ jobs:
       - name: Run py26 tests
         uses: linux-system-roles/lsr-gh-action-py26@1.0.2
         env:
-          TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@3.5.0"
+          TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@3.5.1"
 {% endif %}


### PR DESCRIPTION
3.5.0 was retracted as it was broken.