### PR TITLE
ci: ansible-lint needs collection path; tox-lsr 3.5.1

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -21,6 +21,7 @@ present_templates:
   - .github/workflows/codespell.yml
   - .github/workflows/markdownlint.yml
   - .github/workflows/pr-title-lint.yml
+  - .github/workflows/qemu-kvm-integration-tests.yml
   - .github/workflows/test_converting_readme.yml
   - .github/workflows/tft.yml
   - .github/workflows/tft_citest_bad.yml

--- a/playbooks/templates/.github/workflows/ansible-lint.yml
+++ b/playbooks/templates/.github/workflows/ansible-lint.yml
@@ -83,4 +83,6 @@ jobs:
 {%- raw %}
           working_directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
           requirements_file: ${{ steps.collection.outputs.coll_req_file }}
+        env:
+          ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}/.tox
 {%- endraw +%}

--- a/playbooks/templates/.github/workflows/python-unit-test.yml
+++ b/playbooks/templates/.github/workflows/python-unit-test.yml
@@ -105,5 +105,5 @@ jobs:
       - name: Run py26 tests
         uses: linux-system-roles/lsr-gh-action-py26@1.0.2
         env:
-          TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@3.5.1"
+          TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
 {% endif %}

--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -11,27 +11,52 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
   workflow_dispatch:
-env:
-  TOX_ENV: qemu-ansible-core-2.16
 
 permissions:
   contents: read
+  # This is required for the ability to create/update the Pull request status
+  statuses: write
 jobs:
-  tox:
+  qemu_kvm:
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - centos-9
-          - centos-10
+        scenario:
+          - { image: "centos-9", env: "qemu-ansible-core-2.16" }
+          - { image: "centos-10", env: "qemu-ansible-core-2.17" }
           # ansible/libdnf5 bug: https://issues.redhat.com/browse/RHELMISC-10110
-          # - fedora-41
-          - fedora-42
-
+          # - { image: "fedora-41", env: "qemu-ansible-core-2.17" }
+          - { image: "fedora-42", env: "qemu-ansible-core-2.17" }
     steps:
+      - name: Checkout repo
+        uses: {{ gha_checkout_action }}
+
+      - name: Check if platform is supported
+        id: check_platform
+        run: |
+          set -euxo pipefail
+{%- raw %}
+          image="${{ matrix.scenario.image }}"
+{%- endraw +%}
+
+          # convert image to tag formats
+          platform=
+          platform_version=
+          case "$image" in
+          centos-*) platform=el; platform_version=el"${image#centos-}" ;;
+          fedora-*) platform=fedora; platform_version="${image/-/}" ;;
+          esac
+          supported=
+          if yq -e '.galaxy_info.galaxy_tags[] | select(. == "'${platform_version}'" or . == "'${platform}'")' meta/main.yml; then
+            supported=true
+          fi
+
+          echo "supported=$supported" >> "$GITHUB_OUTPUT"
+
       - name: Set up /dev/kvm
+        if: steps.check_platform.outputs.supported
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm.rules
           sudo udevadm control --reload-rules
@@ -39,45 +64,57 @@ jobs:
           ls -l /dev/kvm
 
       - name: Disable man-db to speed up package install
+        if: steps.check_platform.outputs.supported
         run: |
           echo "set man-db/auto-update false" | sudo debconf-communicate
           sudo dpkg-reconfigure man-db
 
       - name: Install test dependencies
+        if: steps.check_platform.outputs.supported
         run: |
           set -euxo pipefail
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.5.1"
-
-      - name: Checkout repo
-        uses: actions/checkout@v4
+          pip3 install "{{ tox_lsr_url }}"
 
       - name: Configure tox-lsr
-        run: |
-          curl -o ~/.config/linux-system-roles.json https://raw.githubusercontent.com/linux-system-roles/linux-system-roles.github.io/master/download/linux-system-roles.json
+        if: steps.check_platform.outputs.supported
+        run: >-
+          curl -o ~/.config/linux-system-roles.json
+          https://raw.githubusercontent.com/linux-system-roles/linux-system-roles.github.io/master/download/linux-system-roles.json
 
-      - name: Run tox integration tests
+      - name: Run qemu/kvm tox integration tests
+        if: steps.check_platform.outputs.supported
 {%- raw %}
-        run: tox -e ${{ env.TOX_ENV }} -- --image-name ${{ matrix.image }} --make-batch --log-level=debug --
+        run: >-
+          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
+          --log-level=debug --skip-tags tests::infiniband --
 {%- endraw +%}
 
       - name: Test result summary
-        if: always()
+        if: steps.check_platform.outputs.supported && always()
         run: |
           set -euo pipefail
-          while read code start end f; do
+          # some platforms may have setup/cleanup playbooks - need to find the
+          # actual test playbook that starts with tests_
+          while read code start end test_files; do
+              for f in $test_files; do
+                  f="$(basename $f)"
+                  if [[ "$f" =~ ^tests_ ]]; then
+                      break
+                  fi
+              done
               if [ "$code" = "0" ]; then
                   echo -n "PASS: "
               else
                   echo -n "FAIL: "
               fi
-              echo "$(basename $f)"
+              echo "$f"
           done < batch.report
 
       - name: Show test logs on failure
-        if: failure()
+        if: steps.check_platform.outputs.supported && failure()
         run: |
           set -euo pipefail
           for f in tests/*.log; do
@@ -85,3 +122,14 @@ jobs:
               cat "$f"
               echo "::endgroup::"
           done
+
+      - name: Set commit status as success with a description that platform is skipped
+{%- raw %}
+        if: ${{ steps.check_platform.outputs.supported == '' }}
+        uses: myrotvorets/set-commit-status-action@master
+        with:
+          status: success
+          context: "${{ github.workflow }} / qemu_kvm (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
+{%- endraw +%}
+          description: The role does not support this platform. Skipping.
+          targetUrl: ""


### PR DESCRIPTION
Without this - what happens is that the new ansible-lint will install
the collection dependencies in the requirements file in the first
place in ANSIBLE_COLLECTIONS_PATH which will be used instead of
the current code that has been converted to collection format.  When
this happens, any modules/plugins that your PR has added will not be
found.

With this fix, ansible-lint will not overwrite the existing code
which has been converted to collection format.

bump tox-lsr version to 3.5.1
