### PR TITLE
ci: Attach batch.txt, batch.report, and QEMU logs on failures

### DIFF
--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -118,7 +118,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: "logs-${{ matrix.scenario.image }}-${{ matrix.scenario.env }}"
-          path: tests/*.log
+          path: |
+            tests/*.log
+            artifacts/default_provisioners.log
+            artifacts/*.qcow2.*.log
+            batch.txt
+            batch.report
           retention-days: 30
 
       - name: Show test log failures


### PR DESCRIPTION
batch.txt is not predictable (tests are run in file system order, not asciibetically or otherwise reproducibly). To aid with local reproduction, attach the generated batch file to the test artifact.

Also add the QEMU logs.

---

I already applied this to https://github.com/linux-system-roles/storage/pull/519 to test it in action (pun intended), and it has helped me with bisecting the follow-up failure causes. I also tested it in bisect runs on my fork, e.g. https://github.com/martinpitt/lsr-storage/actions/runs/14492269592 has an artifact with a batch file and report included.