### PR TITLE
ci: Skip NVME/SCSI in QEMU GH workflows

### DIFF
--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -89,7 +89,7 @@ jobs:
 {%- raw %}
         run: >-
           tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
-          --log-level=debug --skip-tags tests::infiniband --
+          --log-level=debug --skip-tags tests::infiniband,tests::nvme,tests::scsi --
 {%- endraw +%}
 
       - name: Test result summary


### PR DESCRIPTION
The storage roles has too many tests which causes an ENOSPC on the workflow runners, and they also run for too long. This was already applied in https://github.com/linux-system-roles/storage/commit/ae35218b61e0

---

See https://github.com/linux-system-roles/storage/pull/520#pullrequestreview-2782724748