### PR TITLE
ci: Show exceptions in Ansible logs

### DIFF
--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           set -euo pipefail
           for f in tests/*.log; do
-              if FAIL=$(grep -B100 -A30 "fatal:" "$f"); then
+              if FAIL=$(grep -E -B100 -A30 "fatal:|An exception occurred" "$f"); then
                   echo "::group::$(basename $f)"
                   echo "$FAIL"
                   echo "::endgroup::"


### PR DESCRIPTION
Sometimes tests fail with "An exception occurred during task execution." instead of "fatal:". Catch this case as well.

---

Spotted in https://github.com/linux-system-roles/cockpit/pull/212 where the [initial run](https://github.com/linux-system-roles/cockpit/actions/runs/14637439347/job/41071741897?pr=212#step:12:1) didn't show the actual failure of tests_port2.yml. I added this commit to that PR as well, and the [new run with that commit](https://github.com/linux-system-roles/cockpit/actions/runs/14637916143/job/41073261668?pr=212#step:12:115) shows the proper error.