### PR TITLE
ci: Bump tox-lsr to 3.7.0

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -62,5 +62,5 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v4
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.7.0"
 lsr_rh_distros: "{{ ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky'] + lsr_rh_distros_extra | d([]) }}"


### PR DESCRIPTION
https://github.com/linux-system-roles/tox-lsr/releases/tag/3.7.0 only changes `runcontainer.sh`, which we don't run in CI. So this should not cause any problems. Nevertheless, I tested it in https://github.com/linux-system-roles/sudo/pull/53 and https://github.com/linux-system-roles/cockpit/pull/213.

This paves the way for setting up bootc container build tests/fixes.