### PR TITLE
ci: Bump tox-lsr to 3.7.1

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -62,5 +62,5 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v4
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.7.0"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 lsr_rh_distros: "{{ ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky'] + lsr_rh_distros_extra | d([]) }}"


### PR DESCRIPTION
There are only two `runcontainer.sh` changes which we don't (yet) run in CI, so this should be risk-free. Nevertheless, I'm running the [logging tests on my fork](https://github.com/martinpitt/lsr-logging/actions/runs/14707736285/job/41271995152) against this already.