### PR TITLE
ci: Bump tox-lsr to 3.8.0

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -62,5 +62,5 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v4
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
 lsr_rh_distros: "{{ ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky'] + lsr_rh_distros_extra | d([]) }}"


### PR DESCRIPTION
After landing this, can we do a mass rollout to pick up the test order shuffling, and syncing the projects again for the recent drift? (I'm quite sure there's some half-applied patches somewhere).