### PR TITLE
Fix path and name bug in upload-artifact

### DIFF
--- a/playbooks/templates/.github/workflows/build_docs.yml
+++ b/playbooks/templates/.github/workflows/build_docs.yml
@@ -97,14 +97,8 @@ jobs:
       - name: Upload README.html as an artifact
         uses: actions/upload-artifact@master
         with:
-          name: ${{ env.RELEASE_VERSION }}/README.html
-          path: README.html
-
-      - name: Upload index.html as an artifact
-        uses: actions/upload-artifact@master
-        with:
-          name: docs/index.html
-          path: index.html
+          name: README.html
+          path: ${{ env.RELEASE_VERSION }}/README.html
 
       - name: Commit changes
         run: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Fix mismatched name and path in upload-artifact steps for README.html and index.html in the build_docs workflow