### PR TITLE
ci: use tox-lsr version 3.9.0; improve qemu test error reporting

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -62,5 +62,5 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v4
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.8.0"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.9.0"
 lsr_rh_distros: "{{ ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky'] + lsr_rh_distros_extra | d([]) }}"

--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -124,7 +124,8 @@ jobs:
 {%- raw %}
         run: >-
           tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
-          --log-level=debug --skip-tags tests::infiniband,tests::nvme,tests::scsi --
+          --log-level debug --skip-tags tests::infiniband,tests::nvme,tests::scsi
+          --lsr-report-errors-url DEFAULT --
 {%- endraw +%}
 
       - name: Qemu result summary
@@ -135,15 +136,18 @@ jobs:
           # actual test playbook that starts with tests_
           while read code start end test_files; do
               for f in $test_files; do
-                  f="$(basename $f)"
+                  test_file="$f"
+                  f="$(basename $test_file)"
                   if [[ "$f" =~ ^tests_ ]]; then
                       break
                   fi
               done
               if [ "$code" = "0" ]; then
                   echo -n "PASS: "
+                  mv "$test_file.log" "${test_file}-SUCCESS.log"
               else
                   echo -n "FAIL: "
+                  mv "$test_file.log" "${test_file}-FAIL.log"
               fi
               echo "$f"
           done < batch.report
@@ -160,8 +164,10 @@ jobs:
           for t in tests/tests_*.yml; do
               if tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} $t > ${t}.log 2>&1; then
                   echo "PASS: $(basename $t)"
+                  mv "${t}.log" "${t}-SUCCESS.log"
               else
                   echo "FAIL: $(basename $t)"
+                  mv "${t}.log" "${t}-FAIL.log"
                   rc=1
               fi
           done
@@ -187,13 +193,14 @@ jobs:
         if: steps.check_platform.outputs.supported && failure()
         run: |
           set -euo pipefail
-          for f in tests/*.log; do
-              if FAIL=$(grep -E -B100 -A30 "fatal:|An exception occurred" "$f"); then
-                  echo "::group::$(basename $f)"
-                  echo "$FAIL"
-                  echo "::endgroup::"
-              fi
+          # grab check_logs.py script
+          curl -s -L -o check_logs.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/refs/heads/main/check_logs.py
+          chmod +x check_logs.py
+          declare -a cmdline=(./check_logs.py --github-action-format)
+          for log in tests/*-FAIL.log; do
+              cmdline+=(--lsr-error-log "$log")
           done
+          "${cmdline[@]}"
 
       - name: Set commit status as success with a description that platform is skipped
 {%- raw %}


### PR DESCRIPTION
Use tox-lsr 3.9.0 which has the `--lsr-report-errors-url` flag.  Use
this and `check_logs.py` to improve error reporting in qemu tests.

## Summary by Sourcery

Upgrade CI to use tox-lsr 3.9.0 and enhance QEMU test error reporting by renaming logs and leveraging check_logs.py for formatted failure output

Enhancements:
- Rename per-test logs with SUCCESS/FAIL suffix for clearer results
- Consolidate and format QEMU test failures using the external check_logs.py script

Build:
- Bump tox-lsr dependency to version 3.9.0

CI:
- Enable --lsr-report-errors-url flag in tox invocations
- Fetch and execute check_logs.py in the CI workflow for improved error aggregation