### PR TITLE
ci: Bump tox-lsr to 3.9.1

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -62,5 +62,5 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v4
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.9.0"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.9.1"
 lsr_rh_distros: "{{ ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky'] + lsr_rh_distros_extra | d([]) }}"


### PR DESCRIPTION
Already applied in https://github.com/linux-system-roles/crypto_policies/pull/151

## Summary by Sourcery

Build:
- Update tox-lsr URL to reference version 3.9.1