### PR TITLE
ci: bootc end-to-end support

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -62,5 +62,5 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v4
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.9.1"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.10.0"
 lsr_rh_distros: "{{ ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky'] + lsr_rh_distros_extra | d([]) }}"

--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -113,6 +113,28 @@ jobs:
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
           pip3 install "{{ tox_lsr_url }}"
 
+      # HACK: Drop this when moving this workflow to 26.04 LTS
+      - name: Update podman to 5.x for compatibility with bootc-image-builder's podman 5
+        if: steps.check_platform.outputs.supported && endsWith(matrix.scenario.image, '-bootc')
+        run: |
+          sed 's/noble/plucky/g' /etc/apt/sources.list.d/ubuntu.sources | sudo tee /etc/apt/sources.list.d/plucky.sources >/dev/null
+          cat <<EOF | sudo tee /etc/apt/preferences.d/podman.pref >/dev/null
+          Package: podman buildah golang-github-containers-common crun libgpgme11t64 libgpg-error0 golang-github-containers-image catatonit conmon containers-storage
+          Pin: release n=plucky
+          Pin-Priority: 991
+
+          Package: libsubid4 netavark passt aardvark-dns containernetworking-plugins libslirp0 slirp4netns
+          Pin: release n=plucky
+          Pin-Priority: 991
+
+          Package: *
+          Pin: release n=plucky
+          Pin-Priority: 400
+          EOF
+
+          sudo apt update
+          sudo apt install -y podman crun conmon containers-storage
+
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported
         run: >-

--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -124,7 +124,7 @@ jobs:
 {%- raw %}
         run: >-
           tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
-          --log-level debug --skip-tags tests::infiniband,tests::nvme,tests::scsi
+          --log-level debug $TOX_ARGS
           --lsr-report-errors-url DEFAULT --
 {%- endraw +%}
 

--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -146,7 +146,7 @@ jobs:
 {%- raw %}
         run: >-
           tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
-          --log-level debug $TOX_ARGS
+          --log-level debug $TOX_ARGS --skip-tags tests::bootc-e2e
           --lsr-report-errors-url DEFAULT --
 {%- endraw +%}
 
@@ -194,6 +194,30 @@ jobs:
               fi
           done
           exit $rc
+{%- endraw +%}
+
+      - name: Run bootc validation tests in QEMU
+        if: steps.check_platform.outputs.supported &&
+            startsWith(matrix.scenario.env, 'container') &&
+            endsWith(matrix.scenario.image, '-bootc')
+{%- raw %}
+        run: |
+          set -euxo pipefail
+          env=$(echo "${{ matrix.scenario.env }}" | sed 's/^container-/qemu-/')
+
+          for image_file in $(ls tests/tmp/*/qcow2/disk.qcow2 2>/dev/null); do
+              test="tests/$(basename $(dirname $(dirname $image_file))).yml"
+              if tox -e "$env" -- --image-file "$(pwd)/$image_file" \
+                     --log-level debug $TOX_ARGS \
+                     --lsr-report-errors-url DEFAULT \
+                     -e __bootc_validation=true \
+                     -- "$test" >out 2>&1; then
+                  mv out "${test}-PASS.log"
+              else
+                  mv out "${test}-FAIL.log"
+                  exit 1
+              fi
+          done
 {%- endraw +%}
 
       - name: Upload test logs on failure


### PR DESCRIPTION
These were applied in https://github.com/linux-system-roles/sudo/pull/59 and lay the groundwork for adding bootc end-to-end tests. The changes are backwards compatible and no-ops for roles without e2e tests. Preferably they can get mass-deployed, to avoid having to cherry-pick all these changes manually.

## Summary by Sourcery

Enable bootc end-to-end tests by extending the QEMU CI workflow with Podman 5.x support, customizable tox arguments, and a new validation step for bootc images, and bump tox-lsr to version 3.10.0.

CI:
- Upgrade Podman to 5.x via apt pinning for bootc scenarios
- Pass custom TOX_ARGS and add skip-tags for bootc-e2e in the tox invocation
- Add a QEMU-based bootc validation tests step that runs tests against generated QCOW2 images and logs results