### PR TITLE
add passt to codespell ignores

### DIFF
--- a/playbooks/update_files.yml
+++ b/playbooks/update_files.yml
@@ -319,7 +319,7 @@
             path: "{{ 'vars/main.yml' if __vars_main.stat.exists
               else 'defaults/main.yml' }}"
 
-        - name: Create an empty .codespell_ignores file if it doesn't exist
+        - name: Manage .codespell_ignores
           shell:
             chdir: "{{ git_dir }}"
             cmd: |
@@ -328,7 +328,12 @@
                 touch .codespell_ignores
                 git add .codespell_ignores
                 echo Success
-               fi
+              fi
+              if ! grep -q -x passt .codespell_ignores; then
+                echo passt >> .codespell_ignores
+                git add .codespell_ignores
+                echo Success
+              fi
           register: codespell_ignores
           changed_when: "'Success' in codespell_ignores.stdout"
 


### PR DESCRIPTION
- **ci: Add support for bootc end-to-end validation tests**
- **add passt to .codespell_ignores**

## Summary by Sourcery

Introduce BootC end-to-end validation tests in the QEMU CI pipeline and update the codespell ignore list to include “passt”.

New Features:
- Add a conditional CI step to run BootC end-to-end validation tests in QEMU.

Enhancements:
- Append “passt” to .codespell_ignores idempotently via the update_files playbook.

CI:
- Skip BootC-e2e tagged tests by default in the existing integration workflow.