### PR TITLE
ci: Bump tox-lsr to 3.11.1

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -62,5 +62,5 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v4
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.11.0"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.11.1"
 lsr_rh_distros: "{{ ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky'] + lsr_rh_distros_extra | d([]) }}"


### PR DESCRIPTION
To pick up https://github.com/linux-system-roles/tox-lsr/pull/209. I locally applied that in my [nbde_client bootc branch](https://github.com/martinpitt/lsr-nbde_client/tree/bootc), but let's percolate to all roles over time.

## Summary by Sourcery

CI:
- Update tox-lsr URL to use version 3.11.1