### PR TITLE
ci: Ignore `name[unique]` ansible-lint for selinux and networking

### DIFF
--- a/inventory/host_vars/network.yml
+++ b/inventory/host_vars/network.yml
@@ -9,6 +9,8 @@ ansible_lint:
   extra_vars:
     test_playbook: tests_default.yml
     network_provider: nm
+  skip_list:
+    - name[unique]
 yamllint:
   ignore: |
     tests/roles/

--- a/inventory/host_vars/selinux.yml
+++ b/inventory/host_vars/selinux.yml
@@ -6,6 +6,8 @@ github_actions:
     schedule:
       - cron: "37 4 * * 4"
 ansible_lint:
+  skip_list:
+    - name[unique]
   mock_modules:
     - seboolean
     - selinux


### PR DESCRIPTION
selinux was already done:
https://github.com/linux-system-roles/selinux/commit/beabf096278748b2ec

network is being done in
https://github.com/linux-system-roles/network/pull/793

## Summary by Sourcery

CI:
- Add name[unique] to ansible_lint skip_list for selinux and network