### PR TITLE
ha_cluster - use py311 for pylint

### DIFF
--- a/playbooks/role_templates/ha_cluster/.github/workflows/python-unit-test.yml
+++ b/playbooks/role_templates/ha_cluster/.github/workflows/python-unit-test.yml
@@ -128,7 +128,7 @@ jobs:
           # NOTE: The use of flake8, pylint, black with specific
           # python envs is arbitrary and must be changed in tox-lsr
           case "$toxpyver" in
-          310) toxenvs="${toxenvs},coveralls,flake8,pylint,black" ;;
+          311) toxenvs="${toxenvs},coveralls,flake8,pylint,black" ;;
           *) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

CI:
- Switch linting and formatting tox environments from Python 3.10 to Python 3.11 in the GitHub Actions workflow