### PR TITLE
ci: update ha_cluster unit tests workflow

### DIFF
--- a/playbooks/role_templates/ha_cluster/.github/workflows/python-unit-test.yml
+++ b/playbooks/role_templates/ha_cluster/.github/workflows/python-unit-test.yml
@@ -52,10 +52,18 @@ jobs:
             pcs_version: v0.11.9
             pcs_dir_local: ''
             pcs_site_packages: site-packages
+          - os: ubuntu-22.04
+            pcs_version: v0.11.10
+            pcs_dir_local: ''
+            pcs_site_packages: site-packages
           - os: ubuntu-24.04
             # v0.12.0 contains a bug preventing it being build in CI
             # v0.12.0-lsr-ci fixes that bug while not adding any other changes
             pcs_version: v0.12.0-lsr-ci
+            pcs_dir_local: '/local'
+            pcs_site_packages: dist-packages
+          - os: ubuntu-24.04
+            pcs_version: v0.12.1
             pcs_dir_local: '/local'
             pcs_site_packages: dist-packages
           - os: ubuntu-24.04


### PR DESCRIPTION
add latest pcs versions to test matrix

## Summary by Sourcery

Update the HA cluster role’s Python unit test GitHub Actions workflow to include the latest pcs library versions in the test matrix

CI:
- Add Ubuntu 22.04 matrix entry for pcs_version v0.11.10
- Add Ubuntu 24.04 matrix entry for pcs_version v0.12.1