### PR TITLE
Select failed and cancelled tests when running citest_bad

### DIFF
--- a/playbooks/templates/.github/workflows/tft_citest_bad.yml
+++ b/playbooks/templates/.github/workflows/tft_citest_bad.yml
@@ -35,8 +35,9 @@ jobs:
             echo "The workflow $PENDING_RUN is still running, wait for it to finish to re-run"
             exit 1
           fi
+          # TF tests can fail or can be cancelled due to TF internal issues
           RUN_ID=$(gh api "repos/$REPO/actions/workflows/tft.yml/runs?event=issue_comment" \
-            | jq -r "[.workflow_runs[] | select( .display_title == \"$PR_TITLE\" ) | select( .conclusion == \"failure\" ) | .id][0]")
+            | jq -r "[.workflow_runs[] | select( .display_title == \"$PR_TITLE\" ) | select( .conclusion == \"failure\" or .conclusion == \"cancelled\" ) | .id][0]")
           if [ "$RUN_ID" = "null" ]; then
             echo "Failed workflow not found, exiting"
             exit 1


### PR DESCRIPTION
## Summary by Sourcery

Allow the citest_bad GitHub Actions workflow to pick up both failed and cancelled test runs for rerunning

Enhancements:
- Update the workflow’s filter to select runs with conclusion "failure" or "cancelled"
- Add a comment noting that Terraform tests can be cancelled due to internal issues