### PR TITLE
ci: Pass in __bootc_validation as boolean, not string

### DIFF
--- a/inventory/host_vars/firewall.yml
+++ b/inventory/host_vars/firewall.yml
@@ -8,3 +8,7 @@ github_actions:
   codeql:
     schedule:
       - cron: "48 9 * * 6"
+tmt_hardware:
+  network:
+    - type: eth
+    - type: eth

--- a/inventory/host_vars/network.yml
+++ b/inventory/host_vars/network.yml
@@ -9,8 +9,6 @@ ansible_lint:
   extra_vars:
     test_playbook: tests_default.yml
     network_provider: nm
-  skip_list:
-    - name[unique]
 yamllint:
   ignore: |
     tests/roles/

--- a/inventory/host_vars/selinux.yml
+++ b/inventory/host_vars/selinux.yml
@@ -6,8 +6,6 @@ github_actions:
     schedule:
       - cron: "37 4 * * 4"
 ansible_lint:
-  skip_list:
-    - name[unique]
   mock_modules:
     - seboolean
     - selinux

--- a/playbooks/include_files/network_contributing.md
+++ b/playbooks/include_files/network_contributing.md
@@ -66,3 +66,4 @@ explanation about the NetworkManager API.
     podman stop lsr-ci-c7
     podman rm lsr-ci-c7
     ```
+

--- a/playbooks/templates/.github/workflows/changelog_to_tag.yml
+++ b/playbooks/templates/.github/workflows/changelog_to_tag.yml
@@ -75,7 +75,7 @@ jobs:
           set -euxo pipefail
           sudo apt-get update
           sudo apt install -y git
-          pip install --upgrade pip galaxy-importer ansible-core 'pyyaml<6,>=5.4.1' ruamel_yaml
+          pip install --upgrade pip galaxy-importer ansible-core pyyaml ruamel_yaml
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -210,7 +210,7 @@ jobs:
               if tox -e "$env" -- --image-file "$(pwd)/$image_file" \
                      --log-level debug $TOX_ARGS \
                      --lsr-report-errors-url DEFAULT \
-                     -e __bootc_validation=true \
+                     -e "__bootc_validation: true" \
                      -- "$test" >out 2>&1; then
                   mv out "${test}-PASS.log"
               else


### PR DESCRIPTION
Pass in a YAML true value as `__bootc_validation: true` using
the --extra-vars option to ensure that `__bootc_validation` is
treated as a boolean and not a string value.

`-e "__bootc_validation: true"`

You can also use JSON format:

`-e '{"__bootc_validation": true}'`

but YAML is simpler in this case.

* ensure mssql uses the right pyyaml

* ensure firewall has two network interfaces

* remove some ansible-lint skips that are not needed anymore

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Treat __bootc_validation as a boolean in CI tests, update pyyaml dependency, and adjust host variable configurations

Enhancements:
- Pass __bootc_validation as a YAML boolean in integration test invocations
- Unpin pyyaml in GitHub workflow installs to use the correct version

Documentation:
- Minor blank line addition in network contributing documentation