### PR TITLE
ci: support openSUSE Leap in qemu/kvm test matrix

### DIFF
--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -30,6 +30,7 @@ jobs:
           # ansible/libdnf5 bug: https://issues.redhat.com/browse/RHELMISC-10110
           # - { image: "fedora-41", env: "qemu-ansible-core-2.17" }
           - { image: "fedora-42", env: "qemu-ansible-core-2.19" }
+          - { image: "leap-15.6", env: "qemu-ansible-core-2.18" }
 
           # container
           - { image: "centos-9", env: "container-ansible-core-2.16" }
@@ -64,6 +65,7 @@ jobs:
           case "$image" in
           centos-*) platform=el; platform_version=el"${image#centos-}" ;;
           fedora-*) platform=fedora; platform_version="${image/-/}" ;;
+          leap-*) platform=leap; platform_version="${image}" ;;
           esac
           supported=
           if yq -e '.galaxy_info.galaxy_tags[] | select(. == "'${platform_version}'" or . == "'${platform}'")' meta/main.yml; then


### PR DESCRIPTION
Some of our system roles now support openSUSE Leap so add this
platform to our testing matrix.

## Summary by Sourcery

Add openSUSE Leap 15.6 support to the qemu/kvm GitHub Actions integration test matrix.

CI:
- Include leap-15.6 as a test image with the qemu-ansible-core-2.18 environment in the matrix
- Extend the workflow's platform detection logic to recognize leap-* images