### PR TITLE
ci: bump tox-lsr to 3.12.0

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -62,5 +62,5 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v5
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.11.1"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.12.0"
 lsr_rh_distros: "{{ ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky'] + lsr_rh_distros_extra | d([]) }}"

--- a/inventory/host_vars/podman.yml
+++ b/inventory/host_vars/podman.yml
@@ -5,3 +5,5 @@ github_actions:
 ansible_lint:
   exclude_paths:
     - tests/files/
+  skip_list:
+    - sanity[cannot-ignore]  # wokeignore:rule=sanity


### PR DESCRIPTION
and fix ansible-lint for podman
needed for podman bootc support PR
https://github.com/linux-system-roles/podman/pull/245
