### PR TITLE
ci: tox-lsr 3.17.0 - container test improvements, use ansible 2.20 for fedora 43

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -62,7 +62,7 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v6
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.16.0"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.17.0"
 # These are the supported RHEL-alike distros - note that at the time of writing,
 # OracleLinux has some problems with some roles, so we don't include it here
 # Roles that do support OracleLinux can list it in lsr_rh_distros_extra

--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
           - { image: "centos-9", env: "qemu-ansible-core-2-16" }
           - { image: "centos-10", env: "qemu-ansible-core-2-17" }
           - { image: "fedora-42", env: "qemu-ansible-core-2-19" }
-          - { image: "fedora-43", env: "qemu-ansible-core-2-19" }
+          - { image: "fedora-43", env: "qemu-ansible-core-2-20" }
           - { image: "leap-15.6", env: "qemu-ansible-core-2-18" }
 
           # container
@@ -41,9 +41,9 @@ jobs:
           # - { image: "centos-10", env: "container-ansible-core-2-17" }
           - { image: "centos-10-bootc", env: "container-ansible-core-2-17" }
           - { image: "fedora-42", env: "container-ansible-core-2-17" }
-          - { image: "fedora-43", env: "container-ansible-core-2-19" }
+          - { image: "fedora-43", env: "container-ansible-core-2-20" }
           - { image: "fedora-42-bootc", env: "container-ansible-core-2-17" }
-          - { image: "fedora-43-bootc", env: "container-ansible-core-2-19" }
+          - { image: "fedora-43-bootc", env: "container-ansible-core-2-20" }
 
     env:
       TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"
@@ -184,10 +184,10 @@ jobs:
 {%- raw %}
         run: |
           set -euo pipefail
-          # HACK: debug.py/profile.py setup is broken
-          export LSR_CONTAINER_PROFILE=false
-          export LSR_CONTAINER_PRETTY=false
           rc=0
+          # we cannot skip these on the first test
+          export SKIP_REQUIREMENTS=false
+          export SKIP_CALLBACK_PLUGINS=false
           for t in tests/tests_*.yml; do
               if tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} $t > ${t}.log 2>&1; then
                   echo "PASS: $(basename $t)"
@@ -197,6 +197,9 @@ jobs:
                   mv "${t}.log" "${t}-FAIL.log"
                   rc=1
               fi
+              # we can skip these on subsequent runs
+              export SKIP_REQUIREMENTS=true
+              export SKIP_CALLBACK_PLUGINS=true
           done
           exit $rc
 {%- endraw +%}


### PR DESCRIPTION
tox-lsr 3.17.0 has some container test improvements - better output, faster runs

Use Ansible 2.20 for qemu/container tests on fedora 43

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update CI and test tooling to use newer tox-lsr and Ansible versions and optimize container test execution behavior.

Build:
- Bump tox-lsr dependency reference from 3.16.0 to 3.17.0 in shared inventory configuration.

CI:
- Switch Fedora 43 qemu and container integration test jobs to use Ansible Core 2.20 environments instead of 2.19.
- Adjust container test workflow environment flags to run full setup on the first test and skip requirements and callback plugin setup on subsequent tests for faster execution.