### PR TITLE
ci: use codecov @v6 [citest_skip]

### DIFF
--- a/playbooks/role_templates/ha_cluster/.github/workflows/python-unit-test.yml
+++ b/playbooks/role_templates/ha_cluster/.github/workflows/python-unit-test.yml
@@ -155,4 +155,4 @@ jobs:
           VIRTUALENV_SYSTEM_SITE_PACKAGES=true TOXENV="$toxenvs" lsr_ci_runtox
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6

--- a/playbooks/templates/.github/workflows/python-unit-test.yml
+++ b/playbooks/templates/.github/workflows/python-unit-test.yml
@@ -97,7 +97,7 @@ jobs:
           TOXENV="$toxenvs" lsr_ci_runtox
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
 {%- endraw +%}
 {% if inventory_hostname == 'network' %}
 


### PR DESCRIPTION
use latest version of codecov @v6

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

CI:
- Bump Codecov upload action from v5 to v6 in Python unit test GitHub workflows for role and template playbooks.