### PR TITLE
add auditd role

### DIFF
--- a/inventory/host_vars/auditd.yml
+++ b/inventory/host_vars/auditd.yml
@@ -1,0 +1,7 @@
+github_actions:
+  weekly_ci:
+    schedule:
+      - cron: "0 12 * * 6"
+runtime_collection_requirements:
+  - name: ansible.posix
+test_collection_requirements: []

--- a/inventory/inventory.yml
+++ b/inventory/inventory.yml
@@ -4,6 +4,8 @@ all:
       ansible_host: localhost
     aide:
       ansible_host: localhost
+    auditd:
+      ansible_host: localhost
     auto-maintenance:
       ansible_host: localhost
     bootloader:
@@ -117,6 +119,7 @@ all:
       hosts:
         ad_integration:
         aide:
+        auditd:
         bootloader:
         certificate:
         cockpit:


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Add an auditd host and host group entry to the Ansible inventory for CI coverage.

New Features:
- Introduce an auditd host in the Ansible inventory.
- Configure weekly CI scheduling and collection requirements for the auditd host.