### PR TITLE
ci: add community general to sudo role

### DIFF
--- a/inventory/host_vars/sudo.yml
+++ b/inventory/host_vars/sudo.yml
@@ -7,4 +7,6 @@ github_actions:
       - cron: "4 3 * * 2"
 runtime_collection_requirements:
   - name: ansible.posix
+  - name: community.general
+    version: "{{ community_general_version }}"
 test_collection_requirements: []


### PR DESCRIPTION
Add community.general collection as a runtime dependency for the sudo role to support zypper-related tasks.

## Summary by Sourcery

Build:
- Update sudo role host vars to require the community.general collection at runtime with a configurable version.