### PR TITLE
feat: add role fingerprints to syslog

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -8,6 +8,7 @@ present_files:
   - .ostree/get_ostree_data.sh
   - .ostree/README.md
   - README-ostree.md
+  - library/sr_fingerprint.py
 present_templates:
   - .ansible-lint
   - .codespellrc

--- a/playbooks/files/library/sr_fingerprint.py
+++ b/playbooks/files/library/sr_fingerprint.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: sr_fingerprint
+short_description: Write a message string to syslog using Ansible C(module.log) function.
+description:
+    - Writes the given string to the system log using Ansible C(module.log) function.
+    - Intended for role-internal or diagnostic use.
+author: Rich Megginson (@richm)
+options:
+    sr_message:
+        description: Text to record in syslog.
+        type: str
+        required: true
+"""
+
+EXAMPLES = """
+- name: Record a fingerprint message in syslog
+  sr_fingerprint:
+    sr_message: "system_role:ROLENAME"
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+import datetime
+
+
+def _local_iso8601_no_microseconds():
+    """System local wall clock with local tz offset, ISO 8601, seconds only."""
+    try:
+        utc = datetime.timezone.utc
+    except AttributeError:
+        import time
+
+        return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime())
+    # Prefer the local clock interpreted in the system timezone (not UTC displayed).
+    now = datetime.datetime.now()
+    astimezone = getattr(now, "astimezone", None)
+    if astimezone is not None:
+        try:
+            return astimezone().replace(microsecond=0).isoformat()
+        except (OSError, TypeError, ValueError):
+            pass
+    return datetime.datetime.now(utc).astimezone().replace(microsecond=0).isoformat()
+
+
+def run_module():
+    module_args = dict(
+        sr_message=dict(type="str", required=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    log_message = "%s %s" % (
+        module.params["sr_message"],
+        _local_iso8601_no_microseconds(),
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            message="Check mode: message not logged - [%s]" % log_message,
+        )
+
+    module.log(log_message)
+
+    # we don't actually change anything, so we're not changed - writing a log message
+    # is not considered a change
+    # also, we don't want to report changed every time the role runs
+    module.exit_json(changed=False)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/playbooks/update_files.yml
+++ b/playbooks/update_files.yml
@@ -218,25 +218,29 @@
             basenames: "{{ find.files | map(attribute='path') | map('basename') | sort | list }}"
           changed_when: false
 
-        # uncomment and change to 2.18 when 2.18 is released
-        # - name: Create ignore file for ansible-test 2.17
-        #   shell:
-        #     chdir: "{{ git_dir }}"
-        #     cmd: |
-        #       set -euxo pipefail
-        #       if [ ! -f .sanity-ansible-ignore-2.17.txt ] && [ -f .sanity-ansible-ignore-2.16.txt ]; then
-        #         cp .sanity-ansible-ignore-2.16.txt .sanity-ansible-ignore-2.17.txt
-        #         # 2.17 does not support py27 or py36
-        #         sed -e '/compile-2.7/d' -e '/compile-3.6/d' -e '/import-2.7/d' -e '/import-3.6/d' -i .sanity-ansible-ignore-2.17.txt
-        #         # https://docs.ansible.com/ansible-core/2.17/dev_guide/testing/sanity/no-unicode-literals.html
-        #         sed -e '/no-unicode-literals/d' -i .sanity-ansible-ignore-2.17.txt
-        #         if [ -s .sanity-ansible-ignore-2.17.txt ]; then
-        #           git add .sanity-ansible-ignore-2.17.txt
-        #         else
-        #           rm .sanity-ansible-ignore-2.17.txt
-        #         fi
-        #       fi
-        #   changed_when: true
+        - name: Manage ansible-test ignore files
+          shell:
+            chdir: "{{ git_dir }}"
+            cmd: |
+              set -euxo pipefail
+              max_ver={{ supported_versions[-1] }}
+              last_max_ver={{ supported_versions[-2] }}
+              # ensure the max version file exists - just copy the previous version file
+              if [ ! -f ".sanity-ansible-ignore-${max_ver}.txt" ] && [ -f ".sanity-ansible-ignore-${last_max_ver}.txt" ]; then
+                cp ".sanity-ansible-ignore-${last_max_ver}.txt" ".sanity-ansible-ignore-${max_ver}.txt"
+                git add ".sanity-ansible-ignore-${max_ver}.txt"
+              fi
+              # ensure we have the gplv3 ignore for the sr_fingerprint module
+              sr_fp_line="plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license"
+              for ver in {{ supported_versions | join(" ") }}; do
+                if ! grep -q "$sr_fp_line" ".sanity-ansible-ignore-${ver}.txt"; then
+                  echo "$sr_fp_line" >> ".sanity-ansible-ignore-${ver}.txt"
+                  git add ".sanity-ansible-ignore-${ver}.txt"
+                fi
+              done
+          changed_when: false
+          vars:
+            supported_versions: ["2.14", "2.16", "2.17", "2.18", "2.19", "2.20", "2.21", "2.22"]
 
         # NOTE: Due to https://github.com/linux-system-roles/cockpit/issues/130
         # we cannot automatically create symlinks for OracleLinux


### PR DESCRIPTION
Feature: Add a fingerprint string to the system log to indicate when the role began
successfully, and when the role finished successfully.  The fingerprint string indicates
the role name, a timestamp, and the platform.

Reason: Users can see when the role was used and if it was used successfully.  This
information from the system log can be collected by log scanners and aggregators
for further analysis.

Result: The role logs fingerprints to the system log.

This also adds a test to check if the fingerprints were written upon a successful
role invocation.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Introduce an internal Ansible module to write role fingerprint messages to syslog and ensure supporting project metadata is updated.

New Features:
- Add sr_fingerprint Ansible module to log role fingerprint messages with timestamps to the system log.

Enhancements:
- Register the sr_fingerprint module in active role files so it is deployed with relevant roles.
- Automate maintenance of ansible-test sanity ignore files, including ensuring coverage for the sr_fingerprint module across supported versions.