### PR TITLE
ci: bump github script from @v8 to @v9

### DIFF
--- a/playbooks/templates/.github/workflows/weekly_ci.yml
+++ b/playbooks/templates/.github/workflows/weekly_ci.yml
@@ -52,7 +52,7 @@ jobs:
           git push -f --set-upstream origin ${{ env.BRANCH_NAME }}
 
       - name: Create and comment pull request
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GH_PUSH_TOKEN }}
           script: |


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

CI:
- Update the weekly CI workflow template to use actions/github-script@v9 instead of @v8.