### PR TITLE
Add fedora.linux_system_roles collection requirement for trustee_server

### DIFF
--- a/inventory/host_vars/trustee_server.yml
+++ b/inventory/host_vars/trustee_server.yml
@@ -7,4 +7,5 @@ github_actions:
       - cron: "34 3 * * 2"
 runtime_collection_requirements:
   - name: ansible.posix
+  - name: fedora.linux_system_roles
 test_collection_requirements: []


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Declare fedora.linux_system_roles as a required runtime Ansible collection for trustee_server.