### PR TITLE
Skip reviews for PRs with [citest_skip] in the title

### DIFF
--- a/playbooks/templates/.coderabbit.yaml
+++ b/playbooks/templates/.coderabbit.yaml
@@ -8,6 +8,11 @@ chat:
   art: false
 
 reviews:
+  # Skip reviews for PRs with [citest_skip] in the title
+  auto_review:
+    ignore_title_keywords:
+      - "[citest_skip]"
+
   # Disable fun features
   poem: false
   in_progress_fortune: false

--- a/playbooks/templates/contributing.md
+++ b/playbooks/templates/contributing.md
@@ -20,6 +20,12 @@ are likely to be suitable for new contributors!
 
 **Code** is managed on [Github](https://github.com/linux-system-roles/{{ inventory_hostname }}), using
 [Pull Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
+
+## AI Coding Assistants
+
+The `.coderabbit.yaml` configuration file in the repository root contains coding
+standards and requirements that can be used by AI coding assistants to help
+generate code that follows project conventions.
 {% if 'python_roles' in group_names %}
 
 ## Python Code


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated review tooling updated to skip certain pull requests when the title includes the token [citest_skip].

* **Documentation**
  * Added an "AI Coding Assistants" section to contributing guidance, instructing contributors to consult the repository root configuration for AI-generated code standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linux-system-roles/.github/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->