### PR TITLE
refactor: use ansible.posix 2.1.X for EL7 compatibility

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -78,3 +78,5 @@ lsr_rh_distros: "{{ ['AlmaLinux', 'CentOS', 'RedHat', 'Rocky'] + lsr_rh_distros_
 # If a role needs a different version, the role can define its own community_general_version
 # in the role's host_vars file
 community_general_version: ">=6.6.0,<12.0.0"
+# ansible.posix version 2.2.0 does not work on EL7, so restrict it to 2.1.x
+ansible_posix_version: ">=2.1.0,<2.2.0"

--- a/inventory/host_vars/ad_integration.yml
+++ b/inventory/host_vars/ad_integration.yml
@@ -8,8 +8,10 @@ github_actions:
       - cron: "0 12 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: community.general
     version: "{{ community_general_version }}"
+  - name: fedora.linux_system_roles
 test_collection_requirements:
   - name: ansible.windows
   - name: community.windows

--- a/inventory/host_vars/aide.yml
+++ b/inventory/host_vars/aide.yml
@@ -4,4 +4,5 @@ github_actions:
       - cron: "0 11 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/auditd.yml
+++ b/inventory/host_vars/auditd.yml
@@ -4,4 +4,5 @@ github_actions:
       - cron: "0 12 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/bootloader.yml
+++ b/inventory/host_vars/bootloader.yml
@@ -7,4 +7,5 @@ github_actions:
       - cron: "48 9 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/certificate.yml
+++ b/inventory/host_vars/certificate.yml
@@ -9,6 +9,7 @@ tmt_hardware:
   memory: ">= 4096 MB"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: community.general
     version: "{{ community_general_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/cockpit.yml
+++ b/inventory/host_vars/cockpit.yml
@@ -4,6 +4,7 @@ github_actions:
       - cron: "0 12 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: community.general
     version: "{{ community_general_version }}"
   - name: fedora.linux_system_roles

--- a/inventory/host_vars/crypto_policies.yml
+++ b/inventory/host_vars/crypto_policies.yml
@@ -4,4 +4,5 @@ github_actions:
       - cron: "0 4 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/fapolicyd.yml
+++ b/inventory/host_vars/fapolicyd.yml
@@ -4,4 +4,5 @@ github_actions:
       - cron: "0 12 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/firewall.yml
+++ b/inventory/host_vars/firewall.yml
@@ -16,4 +16,5 @@ tmt_hardware:
     - type: eth
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/gfs2.yml
+++ b/inventory/host_vars/gfs2.yml
@@ -7,5 +7,6 @@ github_actions:
       - cron: "8 10 * * 3"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: fedora.linux_system_roles
 test_collection_requirements: []

--- a/inventory/host_vars/ha_cluster.yml
+++ b/inventory/host_vars/ha_cluster.yml
@@ -16,6 +16,7 @@ ansible_lint:
     - sanity[cannot-ignore]  # wokeignore:rule=sanity
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: community.general
     version: "{{ community_general_version }}"
   - name: fedora.linux_system_roles

--- a/inventory/host_vars/hpc.yml
+++ b/inventory/host_vars/hpc.yml
@@ -7,5 +7,6 @@ github_actions:
       - cron: "48 9 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: fedora.linux_system_roles
 test_collection_requirements: []

--- a/inventory/host_vars/journald.yml
+++ b/inventory/host_vars/journald.yml
@@ -4,4 +4,5 @@ github_actions:
       - cron: "0 12 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/kdump.yml
+++ b/inventory/host_vars/kdump.yml
@@ -4,4 +4,5 @@ github_actions:
       - cron: "0 7 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/kernel_settings.yml
+++ b/inventory/host_vars/kernel_settings.yml
@@ -8,4 +8,5 @@ github_actions:
 role_specific_contributing: include_files/kernel_settings_contributing.md
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/keylime_server.yml
+++ b/inventory/host_vars/keylime_server.yml
@@ -4,6 +4,7 @@ github_actions:
       - cron: "0 9 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: community.general
     version: "{{ community_general_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/logging.yml
+++ b/inventory/host_vars/logging.yml
@@ -7,5 +7,6 @@ ansible_lint:
     - tasks: "**/tasks/*.yml"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: fedora.linux_system_roles
 test_collection_requirements: []

--- a/inventory/host_vars/metrics.yml
+++ b/inventory/host_vars/metrics.yml
@@ -20,5 +20,6 @@ codespell_skip:
   - vendor
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: fedora.linux_system_roles
 test_collection_requirements: []

--- a/inventory/host_vars/nbde_server.yml
+++ b/inventory/host_vars/nbde_server.yml
@@ -7,5 +7,6 @@ github_actions:
       - cron: "48 10 * * 2"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: fedora.linux_system_roles
 test_collection_requirements: []

--- a/inventory/host_vars/network.yml
+++ b/inventory/host_vars/network.yml
@@ -27,4 +27,5 @@ tmt_hardware:
     - type: eth
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/podman.yml
+++ b/inventory/host_vars/podman.yml
@@ -9,6 +9,7 @@ ansible_lint:
     - sanity[cannot-ignore]  # wokeignore:rule=sanity
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: containers.podman
   - name: fedora.linux_system_roles
 test_collection_requirements:

--- a/inventory/host_vars/postfix.yml
+++ b/inventory/host_vars/postfix.yml
@@ -4,5 +4,6 @@ github_actions:
       - cron: "0 17 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: fedora.linux_system_roles
 test_collection_requirements: []

--- a/inventory/host_vars/postgresql.yml
+++ b/inventory/host_vars/postgresql.yml
@@ -7,6 +7,7 @@ ansible_lint:
     - linux-system-roles.certificate
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: fedora.linux_system_roles
   - name: community.general
     version: "{{ community_general_version }}"

--- a/inventory/host_vars/rhc.yml
+++ b/inventory/host_vars/rhc.yml
@@ -4,6 +4,7 @@ github_actions:
       - cron: "0 19 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: community.general
     version: "{{ community_general_version }}"
 test_collection_requirements:

--- a/inventory/host_vars/selinux.yml
+++ b/inventory/host_vars/selinux.yml
@@ -11,6 +11,7 @@ ansible_lint:
     - selinux
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: community.general
     version: "{{ community_general_version }}"
   - name: fedora.linux_system_roles

--- a/inventory/host_vars/snapshot.yml
+++ b/inventory/host_vars/snapshot.yml
@@ -7,5 +7,6 @@ github_actions:
       - cron: "8 10 * * 3"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements:
   - name: fedora.linux_system_roles

--- a/inventory/host_vars/ssh.yml
+++ b/inventory/host_vars/ssh.yml
@@ -5,6 +5,7 @@ github_actions:
 role_specific_contributing: include_files/ssh_contributing.md
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: community.general
     version: "{{ community_general_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/storage.yml
+++ b/inventory/host_vars/storage.yml
@@ -8,5 +8,6 @@ github_actions:
 role_specific_contributing: include_files/storage_contributing.md
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements:
   - name: fedora.linux_system_roles

--- a/inventory/host_vars/sudo.yml
+++ b/inventory/host_vars/sudo.yml
@@ -7,6 +7,7 @@ github_actions:
       - cron: "4 3 * * 2"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: community.general
     version: "{{ community_general_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/systemd.yml
+++ b/inventory/host_vars/systemd.yml
@@ -7,4 +7,5 @@ github_actions:
       - cron: "4 3 * * 2"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/template.yml
+++ b/inventory/host_vars/template.yml
@@ -4,4 +4,5 @@ github_actions:
       - cron: "0 0 * * 6"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/timesync.yml
+++ b/inventory/host_vars/timesync.yml
@@ -12,4 +12,5 @@ ansible_lint:
     targets: target_hosts
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/tlog.yml
+++ b/inventory/host_vars/tlog.yml
@@ -4,6 +4,7 @@ github_actions:
       - cron: "0 3 * * 0"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: community.general
     version: "{{ community_general_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/trustee_client.yml
+++ b/inventory/host_vars/trustee_client.yml
@@ -7,4 +7,5 @@ github_actions:
       - cron: "4 3 * * 2"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
 test_collection_requirements: []

--- a/inventory/host_vars/trustee_server.yml
+++ b/inventory/host_vars/trustee_server.yml
@@ -7,5 +7,6 @@ github_actions:
       - cron: "34 3 * * 2"
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: fedora.linux_system_roles
 test_collection_requirements: []

--- a/inventory/host_vars/vpn.yml
+++ b/inventory/host_vars/vpn.yml
@@ -10,5 +10,6 @@ ansible_lint:
     - sanity[cannot-ignore]  # wokeignore:rule=sanity
 runtime_collection_requirements:
   - name: ansible.posix
+    version: "{{ ansible_posix_version }}"
   - name: fedora.linux_system_roles
 test_collection_requirements: []

--- a/playbooks/update_files.yml
+++ b/playbooks/update_files.yml
@@ -8,6 +8,7 @@
     if exclude_roles | d(false) else "" }}
   connection: local
   gather_facts: false
+  serial: 1  # NOTE: We are being rate limited by github, so only process 1 role at a time
   vars:
     update_files_branch: update_role_files
   tasks:


### PR DESCRIPTION
The recently released ansible.posix 2.2.0 does not work on EL7.
Pin the version of ansible.posix to 2.1.X.

NOTE: Even though this role might not support EL7, this update
is applied to all system roles for consistency.  Plus, when this
role is part of the system roles collection, all roles must use
the same version of ansible.posix - there is no way for a role
which is part of a collection to use a different version of a
dependency than the version used by the other roles.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated ansible.posix collection version constraints to 2.1.0-2.2.0 across playbook configurations.
  * Added fedora.linux_system_roles to required collections.
  * Modified playbook execution to sequential processing for improved stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linux-system-roles/.github/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->