### PR TITLE
ci: remove python 2.6 unit testing

### DIFF
--- a/playbooks/templates/.github/workflows/python-unit-test.yml
+++ b/playbooks/templates/.github/workflows/python-unit-test.yml
@@ -99,16 +99,3 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6
 {%- endraw +%}
-{% if inventory_hostname == 'network' %}
-
-  python-26:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout PR
-        uses: {{ gha_checkout_action }}
-
-      - name: Run py26 tests
-        uses: linux-system-roles/lsr-gh-action-py26@1.0.2
-        env:
-          TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.2"
-{% endif %}


### PR DESCRIPTION
The py26 dependencies are too old and it is too much work to keep
them free of security vulnerabilities

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
