### PR TITLE
ci: ha_cluster: add latest pcs versions to unit test matrix

### DIFF
--- a/playbooks/role_templates/ha_cluster/.github/workflows/python-unit-test.yml
+++ b/playbooks/role_templates/ha_cluster/.github/workflows/python-unit-test.yml
@@ -63,6 +63,10 @@ jobs:
             pcs_version: v0.11.11
             pcs_dir_local: ''
             pcs_site_packages: site-packages
+          - os: ubuntu-22.04
+            pcs_version: v0.11.12
+            pcs_dir_local: ''
+            pcs_site_packages: site-packages
           - os: ubuntu-24.04
             # v0.12.0 contains a bug preventing it being build in CI
             # v0.12.0-lsr-ci fixes that bug while not adding any other changes
@@ -75,6 +79,10 @@ jobs:
             pcs_site_packages: dist-packages
           - os: ubuntu-24.04
             pcs_version: v0.12.2
+            pcs_dir_local: '/local'
+            pcs_site_packages: dist-packages
+          - os: ubuntu-24.04
+            pcs_version: v0.12.3
             pcs_dir_local: '/local'
             pcs_site_packages: dist-packages
           - os: ubuntu-24.04


### PR DESCRIPTION
Apply changes from https://github.com/linux-system-roles/ha_cluster/pull/398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated Python unit test coverage to include additional platform and version combinations, improving confidence in compatibility across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->