### PR TITLE
ci: bump tox-lsr version to 3.20.0 to fix tox 4.58 api breakage [citest_skip]

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -66,7 +66,7 @@ lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
 gha_checkout_action: actions/checkout@v7
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.18.1"
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.20.0"
 # These are the supported RHEL-alike distros - note that at the time of writing,
 # OracleLinux has some problems with some roles, so we don't include it here
 # Roles that do support OracleLinux can list it in lsr_rh_distros_extra


### PR DESCRIPTION
This fixes the tox-lsr related test failures in ansible-lint, et. al. caused
by an internal tox api change in version 4.58

See https://github.com/linux-system-roles/tox-lsr/pull/245 for more info

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
