### PR TITLE
ci: bump setup-python to v7 - bump codeql to v4.27.3 [citest_skip]

### DIFF
--- a/playbooks/templates/.github/workflows/ansible-lint.yml
+++ b/playbooks/templates/.github/workflows/ansible-lint.yml
@@ -47,7 +47,7 @@ jobs:
           pip3 install "{{ tox_lsr_url }}"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
 {%- raw %}
           python-version: ${{ matrix.versions.python }}

--- a/playbooks/templates/.github/workflows/ansible-test.yml
+++ b/playbooks/templates/.github/workflows/ansible-test.yml
@@ -50,7 +50,7 @@ jobs:
           pip3 install "{{ tox_lsr_url }}"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
 {%- raw %}
           python-version: ${{ matrix.versions.python }}

--- a/playbooks/templates/.github/workflows/changelog_to_tag.yml
+++ b/playbooks/templates/.github/workflows/changelog_to_tag.yml
@@ -78,7 +78,7 @@ jobs:
           pip install --upgrade pip galaxy-importer ansible-core pyyaml ruamel_yaml
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
 
       - name: checkout auto-maintenance
         uses: {{ gha_checkout_action }}

--- a/playbooks/templates/.github/workflows/codeql.yml
+++ b/playbooks/templates/.github/workflows/codeql.yml
@@ -37,17 +37,17 @@ jobs:
         uses: {{ gha_checkout_action }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v4.37.3
         with:
 {%- raw %}
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@v4.37.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v4.37.3
         with:
           category: "/language:${{ matrix.language }}"
 {%- endraw +%}

--- a/playbooks/templates/.github/workflows/python-unit-test.yml
+++ b/playbooks/templates/.github/workflows/python-unit-test.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Set up Python 3
         if: ${{ matrix.pyver_os.ver != '2.7' }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.pyver_os.ver }}
 


### PR DESCRIPTION
bump setup-python to v7

bump codeql to v4.27.3

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Python setup workflows to use the latest supported action version.
  - Pinned CodeQL analysis steps to a specific release for more consistent workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->