### PR TITLE
ci: bump codeql to v4.27.4 [citest_skip]

### DIFF
--- a/playbooks/templates/.github/workflows/codeql.yml
+++ b/playbooks/templates/.github/workflows/codeql.yml
@@ -37,17 +37,17 @@ jobs:
         uses: {{ gha_checkout_action }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.3
+        uses: github/codeql-action/init@v4.37.4
         with:
 {%- raw %}
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.37.3
+        uses: github/codeql-action/autobuild@v4.37.4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.3
+        uses: github/codeql-action/analyze@v4.37.4
         with:
           category: "/language:${{ matrix.language }}"
 {%- endraw +%}


### PR DESCRIPTION
bump codeql to v4.27.4

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL workflow actions to the latest patch version for initialization, build, and analysis steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->