### PR TITLE
ci: use commit hash for github action, add persist-credentials false

### DIFF
--- a/inventory/group_vars/active_roles.yml
+++ b/inventory/group_vars/active_roles.yml
@@ -67,8 +67,8 @@ default_ansible_lint:
 lsr_namespace: fedora
 lsr_name: linux_system_roles
 lsr_role_namespace: linux_system_roles  # for ansible-lint
-gha_checkout_action: actions/checkout@v7
-tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@3.20.1"
+gha_checkout_action: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+tox_lsr_url: "git+https://github.com/linux-system-roles/tox-lsr@d594be24ed56e586a5796720d51c261e40c20496"  # 3.20.1
 # These are the supported RHEL-alike distros - note that at the time of writing,
 # OracleLinux has some problems with some roles, so we don't include it here
 # Roles that do support OracleLinux can list it in lsr_rh_distros_extra

--- a/playbooks/role_templates/ha_cluster/.github/workflows/python-unit-test.yml
+++ b/playbooks/role_templates/ha_cluster/.github/workflows/python-unit-test.yml
@@ -101,6 +101,8 @@ jobs:
 
       - name: checkout PR
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Install platform dependencies, python, tox, tox-lsr
         run: |
@@ -120,6 +122,7 @@ jobs:
       - name: Clone pcs
         uses: {{ gha_checkout_action }}
         with:
+          persist-credentials: false
           repository: ClusterLabs/pcs
 {%- raw %}
           ref: ${{ matrix.pcs_version }}
@@ -163,4 +166,4 @@ jobs:
           VIRTUALENV_SYSTEM_SITE_PACKAGES=true TOXENV="$toxenvs" lsr_ci_runtox
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7

--- a/playbooks/templates/.github/workflows/ansible-lint.yml
+++ b/playbooks/templates/.github/workflows/ansible-lint.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Checkout repo
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Install tox, tox-lsr
         run: |
@@ -47,7 +49,7 @@ jobs:
           pip3 install "{{ tox_lsr_url }}"
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
 {%- raw %}
           python-version: ${{ matrix.versions.python }}

--- a/playbooks/templates/.github/workflows/ansible-managed-var-comment.yml
+++ b/playbooks/templates/.github/workflows/ansible-managed-var-comment.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Checkout repo
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Install tox, tox-lsr
         run: |

--- a/playbooks/templates/.github/workflows/ansible-plugin-scan.yml
+++ b/playbooks/templates/.github/workflows/ansible-plugin-scan.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Checkout repo
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Install tox, tox-lsr
         run: |

--- a/playbooks/templates/.github/workflows/ansible-test.yml
+++ b/playbooks/templates/.github/workflows/ansible-test.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Checkout repo
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Install tox, tox-lsr
         run: |
@@ -50,7 +52,7 @@ jobs:
           pip3 install "{{ tox_lsr_url }}"
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
 {%- raw %}
           python-version: ${{ matrix.versions.python }}

--- a/playbooks/templates/.github/workflows/changelog_to_tag.yml
+++ b/playbooks/templates/.github/workflows/changelog_to_tag.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: checkout PR
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Get tag and message from the latest CHANGELOG.md commit
         id: tag
@@ -78,17 +80,19 @@ jobs:
           pip install --upgrade pip galaxy-importer ansible-core pyyaml ruamel_yaml
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
 
       - name: checkout auto-maintenance
         uses: {{ gha_checkout_action }}
         with:
+          persist-credentials: false
           repository: linux-system-roles/auto-maintenance
           path: auto-maintenance
 
       - name: checkout mssql into a separate directory
         uses: {{ gha_checkout_action }}
         with:
+          persist-credentials: false
           path: mssql
 
 {%- raw %}
@@ -174,7 +178,7 @@ jobs:
 
 {% endif %}
       - name: Create tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b  # v6.2
         with:
 {%- raw %}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -183,7 +187,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1
         with:
           tag: ${{ steps.tag.outputs.tagname }}
           name: Version ${{ steps.tag.outputs.tagname }}
@@ -193,7 +197,7 @@ jobs:
 {% if inventory_hostname != "mssql" %}
 
       - name: Publish role to Galaxy
-        uses: robertdebock/galaxy-action@1.2.1
+        uses: robertdebock/galaxy-action@7d89099e09f4385ec4b53eb58c0d120f1ad806dd  # 1.2.1
         with:
 {%- raw %}
           galaxy_api_key: ${{ secrets.galaxy_api_key }}

--- a/playbooks/templates/.github/workflows/codeql.yml
+++ b/playbooks/templates/.github/workflows/codeql.yml
@@ -35,19 +35,21 @@ jobs:
           sudo apt install -y git
       - name: Checkout
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
         with:
 {%- raw %}
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.37.4
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
         with:
           category: "/language:${{ matrix.language }}"
 {%- endraw +%}

--- a/playbooks/templates/.github/workflows/codespell.yml
+++ b/playbooks/templates/.github/workflows/codespell.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630  # v2

--- a/playbooks/templates/.github/workflows/markdownlint.yml
+++ b/playbooks/templates/.github/workflows/markdownlint.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Check out code
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       # CHANGELOG.md is generated automatically from PR titles and descriptions
       # It might have issues but they are not critical

--- a/playbooks/templates/.github/workflows/pr-title-lint.yml
+++ b/playbooks/templates/.github/workflows/pr-title-lint.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: {{ gha_checkout_action }}
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install pr_title_lint.py

--- a/playbooks/templates/.github/workflows/python-unit-test.yml
+++ b/playbooks/templates/.github/workflows/python-unit-test.yml
@@ -46,6 +46,8 @@ jobs:
       - name: checkout PR
 {%- endraw +%}
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 {%- raw %}
 
       - name: Set up Python 2.7
@@ -56,7 +58,7 @@ jobs:
 
       - name: Set up Python 3
         if: ${{ matrix.pyver_os.ver != '2.7' }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
           python-version: ${{ matrix.pyver_os.ver }}
 
@@ -97,5 +99,5 @@ jobs:
           TOXENV="$toxenvs" lsr_ci_runtox
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
 {%- endraw +%}

--- a/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/playbooks/templates/.github/workflows/qemu-kvm-integration-tests.yml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Check if platform is supported
         id: check_platform
@@ -136,7 +138,7 @@ jobs:
 
       - name: Ensure use of podman 5
         if: steps.check_platform.outputs.supported && steps.check_podman_version.outputs.need_podman_update == 1
-        uses: redhat-actions/podman-install@main
+        uses: redhat-actions/podman-install@3b6c60c447c93960c0b76faa0c66c6694bc71350  # main
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported
@@ -226,7 +228,7 @@ jobs:
 
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
 {%- raw %}
           name: "logs-${{ matrix.scenario.image }}-${{ matrix.scenario.env }}"
@@ -255,7 +257,7 @@ jobs:
       - name: Set commit status as success with a description that platform is skipped
 {%- raw %}
         if: ${{ steps.check_platform.outputs.supported == '' }}
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
         with:
           status: success
           context: "${{ github.workflow }} / scenario (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"

--- a/playbooks/templates/.github/workflows/shellcheck.yml
+++ b/playbooks/templates/.github/workflows/shellcheck.yml
@@ -31,10 +31,12 @@ jobs:
 
       - name: Checkout repo
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Run ShellCheck
         id: shellcheck_id
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca  # master
 
       - name: Show file paths scanned
         run: |

--- a/playbooks/templates/.github/workflows/test_converting_readme.yml
+++ b/playbooks/templates/.github/workflows/test_converting_readme.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Check out code
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Remove badges from README.md prior to converting to HTML
         run: sed -i '1,8 {/^\[\!.*actions\/workflows/d}' README.md
@@ -43,7 +45,7 @@ jobs:
             --output README.html README.md
 
       - name: Upload README.html as an artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: README.html
           path: README.html

--- a/playbooks/templates/.github/workflows/tft.yml
+++ b/playbooks/templates/.github/workflows/tft.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Checkout repo
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Get head sha of the PR
         id: head_sha
@@ -55,6 +57,7 @@ jobs:
       - name: Checkout PR
         uses: {{ gha_checkout_action }}
         with:
+          persist-credentials: false
 {%- raw %}
           ref: ${{ steps.head_sha.outputs.head_sha }}
 {%- endraw +%}
@@ -143,7 +146,7 @@ jobs:
 
       - name: Set commit status as pending
         if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: pending
@@ -153,7 +156,7 @@ jobs:
 
       - name: Set commit status as success with a description that platform is skipped
         if: "!contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)"
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: success
@@ -162,7 +165,7 @@ jobs:
           targetUrl: ""
 
       - name: Run test in testing farm
-        uses: sclorg/testing-farm-as-github-action@v4
+        uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1  # v4
         if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
         with:
           git_ref: main
@@ -193,7 +196,7 @@ jobs:
 {%- raw %}
 
       - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a  # master
         if: always() && contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}

--- a/playbooks/templates/.github/workflows/weekly_ci.yml
+++ b/playbooks/templates/.github/workflows/weekly_ci.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Checkout latest code
         uses: {{ gha_checkout_action }}
         with:
+          persist-credentials: true  # needed for commit and push
           fetch-depth: 0
 
 {%- raw %}
@@ -52,7 +53,7 @@ jobs:
           git push -f --set-upstream origin ${{ env.BRANCH_NAME }}
 
       - name: Create and comment pull request
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           github-token: ${{ secrets.GH_PUSH_TOKEN }}
           script: |

--- a/playbooks/templates/.github/workflows/woke.yml
+++ b/playbooks/templates/.github/workflows/woke.yml
@@ -12,10 +12,12 @@ jobs:
     steps:
       - name: Checkout
         uses: {{ gha_checkout_action }}
+        with:
+          persist-credentials: false
 
       - name: Run lsr-woke-action
         # Originally, uses: get-woke/woke-action@v0
-        uses: linux-system-roles/lsr-woke-action@main
+        uses: linux-system-roles/lsr-woke-action@33e72e28c826f05aaee08d0b70c7d2cd9e0a39a7  # main
         with:
           woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml --count-only-error-for-failure"
           # Cause the check to fail on any broke rules


### PR DESCRIPTION
The latest security guidance is to use the full commit hash, which is immutable,
instead of a tag or version, which can be mutable, for the reference to a version
of a github action.  There are known attacks which inserted unauthorized code
in a version tag and moved the tag.  This prevents this sort of attack, at the
cost of more maintenance burden, but dependabot will largely take care of this
for us.

Each version or tag has been replaced with the corresponding commit hash - in some
cases, this is not the latest commit on the main branch, so I would expect to see
some dependabot updates in the near future.  I thought it was safer to do it this
way - preserve existing behavior/functionality - rather than replace and upgrade
to a newer version at the same time.

The coderabbit `Pin the Galaxy action's container image.` issue is tracked at
https://github.com/robertdebock/galaxy-action/issues/16

This also adds `persist-credentials: false` to the actions/checkout tasks so that
any credentials used by that task will not persist for subsequent tasks, for those
workflows that do not need the credentials for subsequent tasks.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Reduced credential exposure during automated repository checkouts by disabling credential persistence across workflows.
  - Improved supply-chain security by pinning automation actions and tooling to reviewed commits instead of mutable tags or branches.

- **Reliability**
  - Increased consistency and reproducibility of testing, linting, scanning, release, and deployment automation by standardizing action versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->